### PR TITLE
--release is now default

### DIFF
--- a/build-app.sh
+++ b/build-app.sh
@@ -1,23 +1,23 @@
 #!/bin/bash
 
-release_flag=""
+debug_flag="--release"
 
 if [ $# -ne 1 ] && [ $# -ne 2 ]; then
-    echo "Usage: $0 <name> [--release]"
+    echo "Usage: $0 <name> [--debug]"
     exit 1
 fi
 
 name="$1"
 
-if [[ "$2" == "--release" ]]; then
-    release_flag="--release"
+if [[ "$2" == "--debug" ]]; then
+    debug_flag=""
 fi
 
 pwd=$(pwd)
 
-# Check if the --release flag is present
-if [[ "$@" == *"--release"* ]]; then
-    release_flag="--release"
+# Check if the --debug flag is present
+if [[ "$@" == *"--debug"* ]]; then
+    debug_flag="--release"
 fi
 
 rm -rf "$pwd/modules/$name/wit" || { echo "Command failed"; exit 1; }
@@ -31,7 +31,7 @@ mkdir -p "$pwd/modules/$name/target/wasm32-unknown-unknown/release" || { echo "C
 
 # Build the module using Cargo
 cargo build \
-  $release_flag \
+  $debug_flag \
   --no-default-features \
   --manifest-path="$pwd/modules/$name/Cargo.toml"\
   --target "wasm32-wasi" || {

--- a/build.sh
+++ b/build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 all=false
-release=""
+debug="--release"
 
 # prase arguments (--all, --release)
 for arg in "$@"; do
@@ -9,8 +9,8 @@ for arg in "$@"; do
         --all)
             all=true
             ;;
-        --release)
-            release="--release"
+        --debug)
+            debug="--release"
             ;;
         *)
             echo "Error: Unrecognized argument: $arg"
@@ -40,7 +40,7 @@ if $all; then
         # Check if it's a directory
         if [ -d "$dir" ]; then
             dir_name=$(basename "$dir")
-            ./build-app.sh "$dir_name" $release
+            ./build-app.sh "$dir_name" $debug
         fi
     done
 # else just compile the ones that have git changes
@@ -53,6 +53,6 @@ if $all; then
 else
     DIRS=($(git -C . status --porcelain | grep 'modules/' | sed -n 's|^.*modules/\([^/]*\)/.*$|\1|p' | sort -u))
     for dir in "${DIRS[@]}"; do
-        ./build-app.sh $dir $release
+        ./build-app.sh $dir $debug
     done
 fi


### PR DESCRIPTION
for debug mode you have to add the `--debug` flag
change was made because the fs bootstrap sequence looks in `/release` directory for builds, makes more sense for the default to build for release with an optional `--debug` flag