### PR TITLE
add .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,19 @@
+### node filesystem config, adjust according to your needs.
+### note, will run with default values if no .env is found.
+
+### for example, if you use remote s3, you might want to set chunk_size to 5mb, and adjust flush_to_cold_interval
+
+### Default values automatically set (s3 defaults to None)
+
+# MEM_BUFFER=5242880        # 5mb
+# CHUNK_SIZE=262144         # 256kb
+# FLUSH_TO_COLD_INTERVAL=60 # 60s
+# ENCRYPTION=true           # true
+# CLOUD_ENABLED=false       # false, controls whether new writes will be to s3 or local
+
+###  Example s3 config
+# S3_ACCESS_KEY=minioadmin
+# S3_SECRET__KEY=minioadmin
+# S3_REGION=eu-north-1
+# S3_BUCKET=uqbar
+# S3_ENDPOINT=http://localhost:9000 


### PR DESCRIPTION
note: .env is not necessary, default values are used if it's not present. 