### PR TITLE
fs errors refactor

### DIFF
--- a/src/filesystem/manifest.rs
+++ b/src/filesystem/manifest.rs
@@ -1,5 +1,5 @@
 use crate::types::*;
-use crate::types::{FileSystemError, ProcessId};
+use crate::types::{FsError, ProcessId};
 use blake3::Hasher;
 use chacha20poly1305::{
     aead::{Aead, AeadCore, KeyInit, OsRng},
@@ -322,7 +322,7 @@ impl Manifest {
         &self,
         manifest: &mut HashMap<FileIdentifier, InMemoryFile>,
         memory_buffer: &mut Vec<u8>,
-    ) -> Result<(), FileSystemError> {
+    ) -> Result<(), FsError> {
         let mut wal_file = self.wal_file.write().await;
         let wal_length_before_flush = wal_file.seek(SeekFrom::End(0)).await?;
 
@@ -355,7 +355,7 @@ impl Manifest {
         Ok(())
     }
 
-    pub async fn flush_to_wal_main(&self) -> Result<(), FileSystemError> {
+    pub async fn flush_to_wal_main(&self) -> Result<(), FsError> {
         // called from main, locks manifest
         // other flush_to_wal gets buffer and others passed in.
         // potentially unify with options.
@@ -394,7 +394,7 @@ impl Manifest {
         Ok(())
     }
 
-    pub async fn write(&self, file: &FileIdentifier, data: &[u8]) -> Result<(), FileSystemError> {
+    pub async fn write(&self, file: &FileIdentifier, data: &[u8]) -> Result<(), FsError> {
         let mut manifest = self.manifest.write().await;
         let mut in_memory_file = InMemoryFile::default();
         let mut memory_buffer = self.memory_buffer.write().await;
@@ -446,7 +446,7 @@ impl Manifest {
         cipher: Option<&XChaCha20Poly1305>,
         in_memory_file: &mut InMemoryFile,
         memory_buffer: &mut Vec<u8>,
-    ) -> Result<(), FileSystemError> {
+    ) -> Result<(), FsError> {
         let chunk_hashes = self.chunk_hashes.read().await;
 
         let chunk_hash: [u8; 32] = blake3::hash(&chunk).into();
@@ -509,9 +509,9 @@ impl Manifest {
         file_id: &FileIdentifier,
         start: Option<u64>,
         length: Option<u64>,
-    ) -> Result<Vec<u8>, FileSystemError> {
-        let file = self.get(file_id).await.ok_or(FileSystemError::LFSError {
-            error: "File not found in manifest".to_string(),
+    ) -> Result<Vec<u8>, FsError> {
+        let file = self.get(file_id).await.ok_or(FsError::NotFound {
+            file: file_id.to_uuid().unwrap_or_default(),
         })?;
         let cipher = &self.cipher;
 
@@ -538,7 +538,7 @@ impl Manifest {
                     };
 
                     if offset as usize + len as usize > memory_buffer.len() {
-                        return Err(FileSystemError::LFSError {
+                        return Err(FsError::MemoryBufferError {
                             error: format!(
                                 "Out of bounds read: offset={}, len={}, memory_buffer size={}",
                                 offset,
@@ -557,8 +557,8 @@ impl Manifest {
                 ChunkLocation::WAL(offset) => {
                     let mut wal_file = self.wal_file.write().await;
                     wal_file.seek(SeekFrom::Start(offset)).await.map_err(|e| {
-                        FileSystemError::LFSError {
-                            error: format!("Failed to seek in WAL file: {}", e),
+                        FsError::IOError {
+                            error: format!("Local WAL seek failed: {}", e),
                         }
                     })?;
                     let len = if encrypted {
@@ -569,8 +569,8 @@ impl Manifest {
 
                     let mut buffer = vec![0u8; len as usize];
                     wal_file.read_exact(&mut buffer).await.map_err(|e| {
-                        FileSystemError::LFSError {
-                            error: format!("Failed to read from WAL file: {}", e),
+                        FsError::IOError {
+                            error: format!("Local WAL read failed: {}", e),
                         }
                     })?;
                     if encrypted {
@@ -584,8 +584,8 @@ impl Manifest {
                         let mut buffer =
                             fs::read(path)
                                 .await
-                                .map_err(|e| FileSystemError::LFSError {
-                                    error: format!("Failed to read from file system: {}", e),
+                                .map_err(|e| FsError::IOError {
+                                    error: format!("Local Cold read failed: {}", e),
                                 })?;
                         if encrypted {
                             buffer = decrypt(&*self.cipher, &buffer)?;
@@ -636,10 +636,10 @@ impl Manifest {
         file_id: &FileIdentifier,
         offset: u64,
         data: &[u8],
-    ) -> Result<(), FileSystemError> {
+    ) -> Result<(), FsError> {
         let mut manifest = self.manifest.write().await;
-        let mut file = self.get(file_id).await.ok_or(FileSystemError::LFSError {
-            error: "File not found in manifest".to_string(),
+        let mut file = self.get(file_id).await.ok_or(FsError::NotFound {
+            file: file_id.to_uuid().unwrap_or_default(),
         })?;
 
         let mut memory_buffer = self.memory_buffer.write().await;
@@ -720,9 +720,9 @@ impl Manifest {
         &self,
         file_id: &FileIdentifier,
         data: &[u8],
-    ) -> Result<(), FileSystemError> {
-        let file = self.get(file_id).await.ok_or(FileSystemError::LFSError {
-            error: "File not found in manifest".to_string(),
+    ) -> Result<(), FsError> {
+        let file = self.get(file_id).await.ok_or(FsError::NotFound {
+            file: file_id.to_uuid().unwrap_or_default(),
         })?;
 
         let offset = file.get_len();
@@ -734,12 +734,12 @@ impl Manifest {
         &self,
         file_id: &FileIdentifier,
         new_length: u64,
-    ) -> Result<(), FileSystemError> {
+    ) -> Result<(), FsError> {
         let mut manifest = self.manifest.write().await;
         let mut in_memory_file = manifest
             .get(file_id)
-            .ok_or(FileSystemError::LFSError {
-                error: "File not found in manifest".to_string(),
+            .ok_or(FsError::NotFound {
+                file: file_id.to_uuid().unwrap_or_default(),
             })?
             .clone();
 
@@ -814,7 +814,7 @@ impl Manifest {
         Ok(())
     }
 
-    pub async fn flush_to_cold(&self) -> Result<(), FileSystemError> {
+    pub async fn flush_to_cold(&self) -> Result<(), FsError> {
         let mut manifest_lock = self.manifest.write().await;
         let mut wal_file = self.wal_file.write().await;
         let mut manifest_file = self.manifest_file.write().await;
@@ -876,8 +876,8 @@ impl Manifest {
 
                         // ensure the memory buffer is large enough
                         if mem_pos + total_len as usize > memory_buffer.len() {
-                            return Err(FileSystemError::LFSError {
-                                error: "Memory buffer is not large enough".to_string(),
+                            return Err(FsError::MemoryBufferError {
+                                error: "membuffer is not large enough".to_string(),
                             });
                         }
                         // copy the chunk data from the memory buffer
@@ -966,7 +966,7 @@ impl Manifest {
         Ok(())
     }
 
-    pub async fn delete(&self, file_id: &FileIdentifier) -> Result<(), FileSystemError> {
+    pub async fn delete(&self, file_id: &FileIdentifier) -> Result<(), FsError> {
         // add a delete entry to the manifest
         let entry = ManifestRecord::Delete(file_id.clone());
         let serialized_entry = bincode::serialize(&entry).unwrap();
@@ -984,7 +984,7 @@ impl Manifest {
         Ok(())
     }
 
-    pub async fn cleanup(&self) -> Result<(), FileSystemError> {
+    pub async fn cleanup(&self) -> Result<(), FsError> {
         let in_use_hashes = self.get_chunk_hashes().await;
 
         // loop through all chunks on disk
@@ -1251,19 +1251,19 @@ fn generate_nonce() -> [u8; 24] {
     nonce
 }
 
-fn encrypt(cipher: &XChaCha20Poly1305, bytes: &[u8]) -> Result<Vec<u8>, aes_gcm::aead::Error> {
+fn encrypt(cipher: &XChaCha20Poly1305, bytes: &[u8]) -> Result<Vec<u8>, FsError> {
     let nonce = generate_nonce();
     let ciphertext = cipher.encrypt(&XNonce::from_slice(&nonce), bytes)?;
     Ok([nonce.to_vec(), ciphertext].concat())
 }
 
-fn decrypt(cipher: &XChaCha20Poly1305, bytes: &[u8]) -> Result<Vec<u8>, aes_gcm::aead::Error> {
+fn decrypt(cipher: &XChaCha20Poly1305, bytes: &[u8]) -> Result<Vec<u8>, FsError> {
     let nonce = XNonce::from_slice(&bytes[..24]);
     let plaintext = cipher.decrypt(nonce, &bytes[24..])?;
     Ok(plaintext)
 }
 
-fn parse_s3_config(config: S3Config) -> Result<(S3Client, String), FileSystemError> {
+fn parse_s3_config(config: S3Config) -> Result<(S3Client, String), FsError> {
     let region = Region::Custom {
         name: config.region.clone(),
         endpoint: config.endpoint.clone(),
@@ -1277,51 +1277,46 @@ fn parse_s3_config(config: S3Config) -> Result<(S3Client, String), FileSystemErr
     Ok((client, config.bucket))
 }
 
-// Error transformations, todo refactor FileSystemError!
-impl From<std::io::Error> for FileSystemError {
+impl From<std::io::Error> for FsError {
     fn from(error: std::io::Error) -> Self {
-        FileSystemError::LFSError {
-            error: format!("IO error: {}", error),
-        }
+        FsError::IOError { error: error.to_string() } 
     }
 }
 
-impl From<aes_gcm::aead::Error> for FileSystemError {
+impl From<aes_gcm::aead::Error> for FsError {
     fn from(error: aes_gcm::aead::Error) -> Self {
-        FileSystemError::LFSError {
-            error: format!("Encryption error: {}", error),
-        }
+        FsError::EncryptionError { error: error.to_string() } 
     }
 }
 
-impl From<RusotoError<PutObjectError>> for FileSystemError {
+impl From<RusotoError<PutObjectError>> for FsError {
     fn from(error: RusotoError<PutObjectError>) -> Self {
-        FileSystemError::LFSError {
-            error: format!("S3 PUT error: {}", error),
+        FsError::S3Error {
+            error: format!("PUT error: {}", error),
         }
     }
 }
 
-impl From<RusotoError<GetObjectError>> for FileSystemError {
+impl From<RusotoError<GetObjectError>> for FsError {
     fn from(error: RusotoError<GetObjectError>) -> Self {
-        FileSystemError::LFSError {
-            error: format!("S3 GET error: {}", error),
+        FsError::S3Error {
+            error: format!("GET error: {}", error),
         }
     }
 }
 
-impl From<RusotoError<DeleteObjectError>> for FileSystemError {
+impl From<RusotoError<DeleteObjectError>> for FsError {
     fn from(error: RusotoError<DeleteObjectError>) -> Self {
-        FileSystemError::LFSError {
-            error: format!("S3 DELETE error: {}", error),
+        FsError::S3Error {
+            error: format!("DELETE error: {}", error),
         }
     }
 }
 
-impl From<RusotoError<ListObjectsV2Error>> for FileSystemError {
+impl From<RusotoError<ListObjectsV2Error>> for FsError {
     fn from(error: RusotoError<ListObjectsV2Error>) -> Self {
-        FileSystemError::LFSError {
-            error: format!("S3 LIST error: {}", error),
+        FsError::S3Error {
+            error: format!("LIST error: {}", error),
         }
     }
 }

--- a/src/filesystem/mod.rs
+++ b/src/filesystem/mod.rs
@@ -506,7 +506,7 @@ async fn handle_request(
             };
 
             let file = FileIdentifier::Process(source.process.clone());
-            match manifest.append(&file, &payload.bytes).await {
+            match manifest.write(&file, &payload.bytes).await {
                 Ok(_) => (),
                 Err(e) => {
                     return Err(FsError::WriteFailed {

--- a/src/types.rs
+++ b/src/types.rs
@@ -382,9 +382,10 @@ pub enum FsError {
     BadBytes { action: String },
     #[error(
         "fs: JSON payload could not be parsed to FsAction: {:?}, error: {:?}.",
-        json, error
+        json,
+        error
     )]
-    BadJson { json: String, error: String},
+    BadJson { json: String, error: String },
     #[error("fs: No JSON payload.")]
     NoJson,
     #[error("fs: Read failed to file {file}: {error}.")]

--- a/src/types.rs
+++ b/src/types.rs
@@ -334,6 +334,7 @@ pub enum FsAction {
     SetLength((u128, u64)),
     GetState,
     SetState,
+    DeleteState,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -375,6 +376,59 @@ pub struct FsConfig {
     // pub flush_to_wal_interval: usize,
 }
 
+#[derive(Error, Debug, Serialize, Deserialize)]
+pub enum FsError {
+    #[error("fs: Bytes payload required for {action}.")]
+    BadBytes { action: String },
+    #[error(
+        "fs: JSON payload could not be parsed to FsAction: {:?}, error: {:?}.",
+        json, error
+    )]
+    BadJson { json: String, error: String},
+    #[error("fs: No JSON payload.")]
+    NoJson,
+    #[error("fs: Read failed to file {file}: {error}.")]
+    ReadFailed { file: u128, error: String },
+    #[error("fs: Write failed to file {file}: {error}.")]
+    WriteFailed { file: u128, error: String },
+    #[error("fs: file not found: {file}")]
+    NotFound { file: u128 },
+    #[error("fs: S3 error: {error}")]
+    S3Error { error: String },
+    #[error("fs: IO error: {error}")]
+    IOError { error: String },
+    #[error("fs: Encryption error: {error}")]
+    EncryptionError { error: String },
+    #[error("fs: Limit error: {error}")]
+    LimitError { error: String },
+    #[error("fs: memory buffer error: {error}")]
+    MemoryBufferError { error: String },
+    #[error("fs: length operation error: {error}")]
+    LengthError { error: String },
+    #[error("fs: creating fs dir failed at path: {path}: {error}")]
+    CreateInitialDirError { path: String, error: String },
+}
+
+impl FsError {
+    pub fn kind(&self) -> &str {
+        match *self {
+            FsError::BadBytes { .. } => "BadBytes",
+            FsError::BadJson { .. } => "BadJson",
+            FsError::NoJson { .. } => "NoJson",
+            FsError::ReadFailed { .. } => "ReadFailed",
+            FsError::WriteFailed { .. } => "WriteFailed",
+            FsError::S3Error { .. } => "S3Error",
+            FsError::IOError { .. } => "IOError",
+            FsError::EncryptionError { .. } => "EncryptionError",
+            FsError::LimitError { .. } => "LimitError",
+            FsError::MemoryBufferError { .. } => "MemoryBufferError",
+            FsError::NotFound { .. } => "NotFound",
+            FsError::LengthError { .. } => "LengthError",
+            FsError::CreateInitialDirError { .. } => "CreateInitialDirError",
+        }
+    }
+}
+
 impl VfsError {
     pub fn kind(&self) -> &str {
         match *self {
@@ -390,151 +444,6 @@ pub enum VfsError {
     BadIdentifier,
     BadDescriptor,
     NoCap,
-}
-
-impl FileSystemError {
-    pub fn kind(&self) -> &str {
-        match *self {
-            FileSystemError::BadUri { .. } => "BadUri",
-            FileSystemError::BadJson { .. } => "BadJson",
-            FileSystemError::BadBytes { .. } => "BadBytes",
-            FileSystemError::IllegalAccess { .. } => "IllegalAccess",
-            FileSystemError::AlreadyOpen { .. } => "AlreadyOpen",
-            FileSystemError::NotCurrentlyOpen { .. } => "NotCurrentlyOpen",
-            FileSystemError::BadPathJoin { .. } => "BadPathJoin",
-            FileSystemError::CouldNotMakeDir { .. } => "CouldNotMakeDir",
-            FileSystemError::ReadFailed { .. } => "ReadFailed",
-            FileSystemError::WriteFailed { .. } => "WriteFailed",
-            FileSystemError::OpenFailed { .. } => "OpenFailed",
-            FileSystemError::FsError { .. } => "FsError",
-            FileSystemError::LFSError { .. } => "LFSErrror",
-        }
-    }
-}
-
-#[derive(Error, Debug, Serialize, Deserialize)]
-pub enum FileSystemError {
-    //  bad input from user
-    #[error("Malformed URI: {uri}. Problem with {bad_part_name}: {:?}.", bad_part)]
-    BadUri {
-        uri: String,
-        bad_part_name: String,
-        bad_part: Option<String>,
-    },
-    #[error(
-        "JSON payload could not be parsed to FileSystemRequest: {error}. Got {:?}.",
-        json
-    )]
-    BadJson { json: String, error: String },
-    #[error("Bytes payload required for {action}.")]
-    BadBytes { action: String },
-    #[error("{process_name} not allowed to access {attempted_dir}. Process may only access within {sandbox_dir}.")]
-    IllegalAccess {
-        process_name: String,
-        attempted_dir: String,
-        sandbox_dir: String,
-    },
-    #[error("Already have {path} opened with mode {:?}.", mode)]
-    AlreadyOpen { path: String, mode: FileSystemMode },
-    #[error("Don't have {path} opened with mode {:?}.", mode)]
-    NotCurrentlyOpen { path: String, mode: FileSystemMode },
-    //  path or underlying fs problems
-    #[error("Failed to join path: base: '{base_path}'; addend: '{addend}'.")]
-    BadPathJoin { base_path: String, addend: String },
-    #[error("Failed to create dir at {path}: {error}.")]
-    CouldNotMakeDir { path: String, error: String },
-    #[error("Failed to read {path}: {error}.")]
-    ReadFailed { path: String, error: String },
-    #[error("Failed to write {path}: {error}.")]
-    WriteFailed { path: String, error: String },
-    #[error("Failed to open {path} for {:?}: {error}.", mode)]
-    OpenFailed {
-        path: String,
-        mode: FileSystemMode,
-        error: String,
-    },
-    #[error("Filesystem error while {what} on {path}: {error}.")]
-    FsError {
-        what: String,
-        path: String,
-        error: String,
-    },
-    #[error("LFS error: {error}.")]
-    LFSError { error: String },
-}
-
-#[derive(Debug, Serialize, Deserialize)]
-pub struct FileSystemRequest {
-    pub uri_string: String,
-    pub action: FileSystemAction,
-}
-
-#[derive(Debug, Serialize, Deserialize)]
-pub enum FileSystemAction {
-    Read,
-    Write,
-    GetMetadata,
-    ReadDir,
-    Open(FileSystemMode),
-    Close(FileSystemMode),
-    Append,
-    ReadChunkFromOpen(u64),
-    SeekWithinOpen(FileSystemSeekFrom),
-}
-
-//  copy of std::io::SeekFrom with Serialize/Deserialize
-#[derive(Debug, Serialize, Deserialize)]
-pub enum FileSystemSeekFrom {
-    Start(u64),
-    End(i64),
-    Current(i64),
-}
-
-#[derive(Debug, Serialize, Deserialize)]
-pub enum FileSystemResponse {
-    Read(FileSystemUriHash),
-    Write(String),
-    GetMetadata(FileSystemMetadata),
-    ReadDir(Vec<FileSystemMetadata>),
-    Open {
-        uri_string: String,
-        mode: FileSystemMode,
-    },
-    Close {
-        uri_string: String,
-        mode: FileSystemMode,
-    },
-    Append(String),
-    ReadChunkFromOpen(FileSystemUriHash),
-    SeekWithinOpen(String),
-}
-
-#[derive(Debug, Serialize, Deserialize)]
-pub struct FileSystemUriHash {
-    pub uri_string: String,
-    pub hash: u64,
-}
-
-#[derive(Debug, Serialize, Deserialize)]
-pub struct FileSystemMetadata {
-    pub uri_string: String,
-    pub hash: Option<u64>,
-    pub entry_type: FileSystemEntryType,
-    pub len: u64,
-}
-
-#[derive(Eq, Hash, PartialEq, Clone, Debug, Serialize, Deserialize)]
-pub enum FileSystemMode {
-    Read,
-    Append,
-    AppendOverwrite,
-}
-
-#[derive(Debug, Serialize, Deserialize)]
-pub enum FileSystemEntryType {
-    Symlink,
-    File,
-    Dir,
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/src/vfs.rs
+++ b/src/vfs.rs
@@ -309,22 +309,15 @@ pub async fn vfs(
                     ..
                 }) = message.clone()
                 else {
-                    //  println!("vfs: {}", message);
+                    // consider moving this handling into it's own function
                     continue;
-                    // return Err(FileSystemError::BadJson {
-                    //     json: "".into(),
-                    //     error: "not a Request with payload".into(),
-                    // });
                 };
 
                 let request: VfsRequest = match serde_json::from_str(&ipc) {
                     Ok(r) => r,
                     Err(e) => {
-                        panic!("{}", e);
-                        // return Err(FileSystemError::BadJson {
-                        //     json: ipc.into(),
-                        //     error: format!("parse failed: {:?}", e),
-                        // })
+                        println!("vfs: got invalid Request: {}", e);
+                        continue;
                     }
                 };
 

--- a/src/vfs.rs
+++ b/src/vfs.rs
@@ -199,7 +199,7 @@ async fn load_state_from_reboot(
         return false;
     };
     let Ok(Ok(FsResponse::GetState)) =
-        serde_json::from_str::<Result<FsResponse, FileSystemError>>(&ipc.unwrap_or_default())
+        serde_json::from_str::<Result<FsResponse, FsError>>(&ipc.unwrap_or_default())
     else {
         return false;
     };
@@ -1188,7 +1188,7 @@ async fn match_request(
                                 panic!("");
                             };
                             let Ok(FsResponse::Read(read_hash)) =
-                                serde_json::from_str::<Result<FsResponse, FileSystemError>>(&ipc)
+                                serde_json::from_str::<Result<FsResponse, FsError>>(&ipc)
                                     .unwrap()
                             else {
                                 panic!("");
@@ -1272,7 +1272,7 @@ async fn match_request(
                 panic!("");
             };
             let Ok(FsResponse::ReadChunk(read_hash)) =
-                serde_json::from_str::<Result<FsResponse, FileSystemError>>(&ipc).unwrap()
+                serde_json::from_str::<Result<FsResponse, FsError>>(&ipc).unwrap()
             else {
                 panic!("");
             };
@@ -1355,7 +1355,7 @@ async fn match_request(
                     panic!("");
                 };
                 let Ok(FsResponse::Length(length)) =
-                    serde_json::from_str::<Result<FsResponse, FileSystemError>>(&ipc).unwrap()
+                    serde_json::from_str::<Result<FsResponse, FsError>>(&ipc).unwrap()
                 else {
                     panic!("");
                 };

--- a/src/vfs.rs
+++ b/src/vfs.rs
@@ -1188,8 +1188,7 @@ async fn match_request(
                                 panic!("");
                             };
                             let Ok(FsResponse::Read(read_hash)) =
-                                serde_json::from_str::<Result<FsResponse, FsError>>(&ipc)
-                                    .unwrap()
+                                serde_json::from_str::<Result<FsResponse, FsError>>(&ipc).unwrap()
                             else {
                                 panic!("");
                             };


### PR DESCRIPTION
Doesn't change how processes currently switch on Result<FsResponse, FsError>

Tried to go for a flow where you'll get a general (this action failed: {action}, with this inner detailed error: {error})

note: we need to clean up vfs panics [x], ~~and u128 -> u64 for file_uuids~~