### PR TITLE
kernel fixes and key value updates

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -43,37 +43,19 @@ fn build_app(target_path: &str, name: &str, parent_pkg_path: Option<&str>) {
     )
     .unwrap_or(true)
     {
-        run_command(Command::new("cp").args(&[
-            "-r",
-            "wit",
-            target_path,
-        ]))
-        .unwrap();
+        run_command(Command::new("cp").args(&["-r", "wit", target_path])).unwrap();
         // create target/bindings directory
-        fs::create_dir_all(&format!(
-            "{}/target/bindings/{}",
-            target_path,
-            name,
-        ))
-        .unwrap();
+        fs::create_dir_all(&format!("{}/target/bindings/{}", target_path, name,)).unwrap();
         // copy newly-made target.wasm into target/bindings
         run_command(Command::new("cp").args(&[
             "target.wasm",
-            &format!(
-                "{}/target/bindings/{}/",
-                target_path,
-                name,
-            ),
+            &format!("{}/target/bindings/{}/", target_path, name,),
         ]))
         .unwrap();
         // copy newly-made world into target/bindings
         run_command(Command::new("cp").args(&[
             "world",
-            &format!(
-                "{}/target/bindings/{}/",
-                target_path,
-                name,
-            ),
+            &format!("{}/target/bindings/{}/", target_path, name,),
         ]))
         .unwrap();
     }
@@ -93,7 +75,10 @@ fn build_app(target_path: &str, name: &str, parent_pkg_path: Option<&str>) {
         "new",
         &format!("{}/target/wasm32-wasi/release/{}.wasm", target_path, name),
         "-o",
-        &format!("{}/target/wasm32-wasi/release/{}_adapted.wasm", target_path, name),
+        &format!(
+            "{}/target/wasm32-wasi/release/{}_adapted.wasm",
+            target_path, name
+        ),
         "--adapt",
         &format!("{}/wasi_snapshot_preview1.wasm", pwd.display()),
     ]))
@@ -115,7 +100,10 @@ fn build_app(target_path: &str, name: &str, parent_pkg_path: Option<&str>) {
         "wit",
         "--world",
         "uq-process",
-        &format!("{}/target/wasm32-wasi/release/{}_adapted.wasm", target_path, name),
+        &format!(
+            "{}/target/wasm32-wasi/release/{}_adapted.wasm",
+            target_path, name
+        ),
         "-o",
         &wasm_dest_path,
     ]))
@@ -147,7 +135,8 @@ fn main() {
         "terminal",
     ];
 
-    if std::env::var("REBUILD_ALL").is_ok() {} else {
+    if std::env::var("REBUILD_ALL").is_ok() {
+    } else {
         for name in &WASI_APPS {
             println!("cargo:rerun-if-changed=modules/{}/src", name);
             println!("cargo:rerun-if-changed=modules/{}/pkg/manifest.json", name);
@@ -174,7 +163,11 @@ fn main() {
         let entry_path = entry.unwrap().path();
         // If Cargo.toml is present, build the app
         if entry_path.join("Cargo.toml").exists() {
-            build_app(&entry_path.display().to_string(), &entry_path.file_name().unwrap().to_str().unwrap(), None);
+            build_app(
+                &entry_path.display().to_string(),
+                &entry_path.file_name().unwrap().to_str().unwrap(),
+                None,
+            );
         } else if entry_path.is_dir() {
             let parent_pkg_path = format!("{}/pkg", entry_path.display());
             fs::create_dir_all(&parent_pkg_path).unwrap();
@@ -183,12 +176,21 @@ fn main() {
             for sub_entry in std::fs::read_dir(&entry_path).unwrap() {
                 let sub_entry_path = sub_entry.unwrap().path();
                 if sub_entry_path.join("Cargo.toml").exists() {
-                    build_app(&sub_entry_path.display().to_string(), &sub_entry_path.file_name().unwrap().to_str().unwrap(), Some(&parent_pkg_path));
+                    build_app(
+                        &sub_entry_path.display().to_string(),
+                        &sub_entry_path.file_name().unwrap().to_str().unwrap(),
+                        Some(&parent_pkg_path),
+                    );
                 }
             }
 
             // After processing all sub-apps, zip the parent's pkg/ directory
-            let writer = std::fs::File::create(format!("{}/target/{}.zip", pwd.display(), entry_path.file_name().unwrap().to_str().unwrap())).unwrap();
+            let writer = std::fs::File::create(format!(
+                "{}/target/{}.zip",
+                pwd.display(),
+                entry_path.file_name().unwrap().to_str().unwrap()
+            ))
+            .unwrap();
             let options = zip::write::FileOptions::default()
                 .compression_method(zip::CompressionMethod::Stored)
                 .unix_permissions(0o755);
@@ -196,7 +198,9 @@ fn main() {
             for sub_entry in walkdir::WalkDir::new(&parent_pkg_path) {
                 let sub_entry = sub_entry.unwrap();
                 let path = sub_entry.path();
-                let name = path.strip_prefix(std::path::Path::new(&parent_pkg_path)).unwrap();
+                let name = path
+                    .strip_prefix(std::path::Path::new(&parent_pkg_path))
+                    .unwrap();
 
                 // Write a directory or file to the ZIP archive
                 if path.is_file() {

--- a/modules/app_tracker/pkg/manifest.json
+++ b/modules/app_tracker/pkg/manifest.json
@@ -5,8 +5,8 @@
         "on_panic": "Restart",
         "request_networking": true,
         "request_messaging": [
-            "http_bindings:sys:uqbar",
-            "terminal:sys:uqbar",
+            "http_bindings:http_bindings:uqbar",
+            "terminal:terminal:uqbar",
             "filesystem:sys:uqbar",
             "http_server:sys:uqbar",
             "http_client:sys:uqbar",

--- a/modules/app_tracker/pkg/manifest.json
+++ b/modules/app_tracker/pkg/manifest.json
@@ -1,7 +1,7 @@
 [
     {
         "process_name": "app_tracker",
-        "process_wasm_path": "app_tracker.wasm",
+        "process_wasm_path": "/app_tracker.wasm",
         "on_panic": "Restart",
         "request_networking": true,
         "request_messaging": [

--- a/modules/app_tracker/pkg/metadata.json
+++ b/modules/app_tracker/pkg/metadata.json
@@ -1,5 +1,5 @@
 {
-    "package": "sys",
+    "package": "app_tracker",
     "publisher": "uqbar",
     "desc": "A package manager + app store. This JSON field is optional and you can add whatever you want in addition to this."
 }

--- a/modules/app_tracker/src/lib.rs
+++ b/modules/app_tracker/src/lib.rs
@@ -222,7 +222,7 @@ fn parse_command(our: &Address, request_string: String) -> anyhow::Result<()> {
 
 impl Guest for Component {
     fn init(our: Address) {
-        assert_eq!(our.process.to_string(), "app_tracker:sys:uqbar");
+        assert_eq!(our.process.to_string(), "app_tracker:app_tracker:uqbar");
         print_to_terminal(0, &format!("app_tracker: start"));
         loop {
             let message = match receive() {

--- a/modules/chess/pkg/manifest.json
+++ b/modules/chess/pkg/manifest.json
@@ -1,7 +1,7 @@
 [
     {
         "process_name": "chess",
-        "process_wasm_path": "chess.wasm",
+        "process_wasm_path": "/chess.wasm",
         "on_panic": "Restart",
         "request_networking": true,
         "request_messaging": [

--- a/modules/chess/pkg/manifest.json
+++ b/modules/chess/pkg/manifest.json
@@ -5,7 +5,7 @@
         "on_panic": "Restart",
         "request_networking": true,
         "request_messaging": [
-            "http_bindings:sys:uqbar",
+            "http_bindings:http_bindings:uqbar",
             "encryptor:sys:uqbar",
             "http_server:sys:uqbar"
         ],

--- a/modules/chess/pkg/metadata.json
+++ b/modules/chess/pkg/metadata.json
@@ -1,4 +1,4 @@
 {
-    "package": "sys",
+    "package": "chess",
     "publisher": "uqbar"
 }

--- a/modules/chess/src/lib.rs
+++ b/modules/chess/src/lib.rs
@@ -176,7 +176,7 @@ impl Guest for Component {
 
         let bindings_address = Address {
             node: our.node.clone(),
-            process: ProcessId::from_str("http_bindings:sys:uqbar").unwrap(),
+            process: ProcessId::from_str("http_bindings:http_bindings:uqbar").unwrap(),
         };
 
         // <address, request, option<context>, option<payload>>
@@ -471,7 +471,7 @@ impl Guest for Component {
                             continue;
                         }
                     }
-                } else if source.process.to_string() == "http_bindings:sys:uqbar" {
+                } else if source.process.to_string() == "http_bindings:http_bindings:uqbar" {
                     let path = message_json["path"].as_str().unwrap_or("");
                     let method = message_json["method"].as_str().unwrap_or("");
 

--- a/modules/homepage/pkg/manifest.json
+++ b/modules/homepage/pkg/manifest.json
@@ -5,7 +5,7 @@
         "on_panic": "Restart",
         "request_networking": false,
         "request_messaging": [
-            "http_bindings:sys:uqbar",
+            "http_bindings:http_bindings:uqbar",
             "http_server:sys:uqbar",
             "encryptor:sys:uqbar"
         ],

--- a/modules/homepage/pkg/manifest.json
+++ b/modules/homepage/pkg/manifest.json
@@ -1,7 +1,7 @@
 [
     {
         "process_name": "homepage",
-        "process_wasm_path": "homepage.wasm",
+        "process_wasm_path": "/homepage.wasm",
         "on_panic": "Restart",
         "request_networking": false,
         "request_messaging": [

--- a/modules/homepage/pkg/metadata.json
+++ b/modules/homepage/pkg/metadata.json
@@ -1,4 +1,4 @@
 {
-    "package": "sys",
+    "package": "homepage",
     "publisher": "uqbar"
 }

--- a/modules/homepage/src/lib.rs
+++ b/modules/homepage/src/lib.rs
@@ -36,7 +36,7 @@ impl Guest for Component {
 
         let bindings_address = Address {
             node: our.node.clone(),
-            process: ProcessId::from_str("http_bindings:sys:uqbar").unwrap(),
+            process: ProcessId::from_str("http_bindings:http_bindings:uqbar").unwrap(),
         };
 
         // <address, request, option<context>, option<payload>>

--- a/modules/http_bindings/pkg/manifest.json
+++ b/modules/http_bindings/pkg/manifest.json
@@ -1,7 +1,7 @@
 [
     {
         "process_name": "http_bindings",
-        "process_wasm_path": "http_bindings.wasm",
+        "process_wasm_path": "/http_bindings.wasm",
         "on_panic": "Restart",
         "request_networking": false,
         "request_messaging": [

--- a/modules/http_bindings/pkg/metadata.json
+++ b/modules/http_bindings/pkg/metadata.json
@@ -1,4 +1,4 @@
 {
-    "package": "sys",
+    "package": "http_bindings",
     "publisher": "uqbar"
 }

--- a/modules/http_proxy/pkg/manifest.json
+++ b/modules/http_proxy/pkg/manifest.json
@@ -1,7 +1,7 @@
 [
     {
         "process_name": "http_proxy",
-        "process_wasm_path": "http_proxy.wasm",
+        "process_wasm_path": "/http_proxy.wasm",
         "on_panic": "Restart",
         "request_networking": false,
         "request_messaging": [

--- a/modules/http_proxy/pkg/manifest.json
+++ b/modules/http_proxy/pkg/manifest.json
@@ -5,7 +5,7 @@
         "on_panic": "Restart",
         "request_networking": false,
         "request_messaging": [
-            "http_bindings:sys:uqbar",
+            "http_bindings:http_bindings:uqbar",
             "encryptor:sys:uqbar",
             "http_server:sys:uqbar"
         ],

--- a/modules/http_proxy/pkg/metadata.json
+++ b/modules/http_proxy/pkg/metadata.json
@@ -1,4 +1,4 @@
 {
-    "package": "sys",
+    "package": "http_proxy",
     "publisher": "uqbar"
 }

--- a/modules/http_proxy/src/lib.rs
+++ b/modules/http_proxy/src/lib.rs
@@ -62,7 +62,7 @@ impl Guest for Component {
 
         let bindings_address = Address {
             node: our.node.clone(),
-            process: ProcessId::from_str("http_bindings:sys:uqbar").unwrap(),
+            process: ProcessId::from_str("http_bindings:http_bindings:uqbar").unwrap(),
         };
 
         // <address, request, option<context>, option<payload>>
@@ -380,7 +380,7 @@ impl Guest for Component {
                     send_request(
                         &Address {
                             node: username.into(),
-                            process: ProcessId::from_str("http_bindings:sys:uqbar").unwrap(),
+                            process: ProcessId::from_str("http_bindings:http_bindings:uqbar").unwrap(),
                         },
                         &Request {
                             inherit: true,

--- a/modules/key_value/key_value_worker/src/lib.rs
+++ b/modules/key_value/key_value_worker/src/lib.rs
@@ -26,29 +26,29 @@ fn get_payload_wrapped() -> Option<(Option<String>, Vec<u8>)> {
 
 fn send_and_await_response_wrapped(
     target_node: String,
-    target_process: Result<u64, String>,
+    target_process: String,
+    target_package: String,
+    target_publisher: String,
     request_ipc: Option<String>,
     request_metadata: Option<String>,
     payload: Option<(Option<String>, Vec<u8>)>,
     timeout: u64,
-) -> (
-    (String, Result<u64, String>),
-    (Option<String>, Option<String>),
-) {
+) -> (Option<String>, Option<String>) {
     let payload = match payload {
         None => None,
         Some((mime, bytes)) => Some(Payload { mime, bytes }),
     };
     let (
-        Address { node, process },
+        _,
         Message::Response((Response { ipc, metadata }, _)),
     ) = send_and_await_response(
         &Address {
             node: target_node,
-            process: match target_process {
-                Ok(id) => ProcessId::Id(id),
-                Err(name) => ProcessId::Name(name),
-            },
+            process: kt::ProcessId::new(
+                &target_process,
+                &target_package,
+                &target_publisher,
+            ).en_wit(),
         },
         &Request {
             inherit: false,
@@ -63,16 +63,7 @@ fn send_and_await_response_wrapped(
     ).unwrap() else {
         panic!("");
     };
-    (
-        (
-            node,
-            match process {
-                ProcessId::Id(id) => Ok(id),
-                ProcessId::Name(name) => Err(name),
-            },
-        ),
-        (ipc, metadata)
-    )
+    (ipc, metadata)
 }
 
 fn handle_message (

--- a/modules/key_value/pkg/manifest.json
+++ b/modules/key_value/pkg/manifest.json
@@ -1,0 +1,14 @@
+[
+    {
+        "process_name": "key_value",
+        "process_wasm_path": "/key_value.wasm",
+        "on_panic": "Restart",
+        "request_networking": false,
+        "request_messaging": [
+            "vfs:sys:uqbar"
+        ],
+        "grant_messaging": [
+            "all"
+        ]
+    }
+]

--- a/modules/key_value/pkg/metadata.json
+++ b/modules/key_value/pkg/metadata.json
@@ -1,0 +1,4 @@
+{
+    "package": "sys",
+    "publisher": "uqbar"
+}

--- a/modules/key_value/pkg/metadata.json
+++ b/modules/key_value/pkg/metadata.json
@@ -1,4 +1,4 @@
 {
-    "package": "sys",
+    "package": "key_value",
     "publisher": "uqbar"
 }

--- a/modules/orgs/pkg/manifest.json
+++ b/modules/orgs/pkg/manifest.json
@@ -5,7 +5,7 @@
         "on_panic": "Restart",
         "request_networking": true,
         "request_messaging": [
-            "http_bindings:sys:uqbar"
+            "http_bindings:http_bindings:uqbar"
         ],
         "grant_messaging": []
     }

--- a/modules/orgs/pkg/manifest.json
+++ b/modules/orgs/pkg/manifest.json
@@ -1,7 +1,7 @@
 [
     {
         "process_name": "orgs",
-        "process_wasm_path": "orgs.wasm",
+        "process_wasm_path": "/orgs.wasm",
         "on_panic": "Restart",
         "request_networking": true,
         "request_messaging": [

--- a/modules/orgs/pkg/metadata.json
+++ b/modules/orgs/pkg/metadata.json
@@ -1,4 +1,4 @@
 {
-    "package": "sys",
+    "package": "orgs",
     "publisher": "uqbar"
 }

--- a/modules/orgs/src/lib.rs
+++ b/modules/orgs/src/lib.rs
@@ -662,7 +662,7 @@ impl Guest for Component {
 
         let bindings_address = Address {
             node: our.node.clone(),
-            process: ProcessId::from_str("http_bindings:sys:uqbar").unwrap(),
+            process: ProcessId::from_str("http_bindings:http_bindings:uqbar").unwrap(),
         };
 
         // <address, request, option<context>, option<payload>>

--- a/modules/qns_indexer/pkg/manifest.json
+++ b/modules/qns_indexer/pkg/manifest.json
@@ -1,7 +1,7 @@
 [
     {
         "process_name": "qns_indexer",
-        "process_wasm_path": "qns_indexer.wasm",
+        "process_wasm_path": "/qns_indexer.wasm",
         "on_panic": "Restart",
         "request_networking": true,
         "request_messaging": [

--- a/modules/qns_indexer/pkg/manifest.json
+++ b/modules/qns_indexer/pkg/manifest.json
@@ -6,7 +6,7 @@
         "request_networking": true,
         "request_messaging": [
             "net:sys:uqbar",
-            "http_bindings:sys:uqbar",
+            "http_bindings:http_bindings:uqbar",
             "eth_rpc:sys:uqbar"
         ],
         "grant_messaging": [

--- a/modules/qns_indexer/pkg/metadata.json
+++ b/modules/qns_indexer/pkg/metadata.json
@@ -1,4 +1,4 @@
 {
-    "package": "sys",
+    "package": "qns_indexer",
     "publisher": "uqbar"
 }

--- a/modules/qns_indexer/src/lib.rs
+++ b/modules/qns_indexer/src/lib.rs
@@ -153,10 +153,13 @@ impl UqProcess for Component {
             None,
         );
 
+        let http_bindings_process_id_str = "http_bindings:http_bindings:uqbar";
+        let http_bindings_process_id = ProcessId::from_str(http_bindings_process_id_str).unwrap();
+
         let _register_endpoint = send_request(
             &Address {
                 node: our.node.clone(),
-                process: ProcessId::from_str("http_bindings:sys:uqbar").unwrap(),
+                process: http_bindings_process_id.clone(),
             },
             &Request {
                 inherit: false,
@@ -188,7 +191,7 @@ impl UqProcess for Component {
                 continue;
             };
 
-            if source.process.to_string() == "http_bindings:sys:uqbar" {
+            if source.process.to_string() == http_bindings_process_id_str {
                 if let Ok(ipc_json) = serde_json::from_str::<serde_json::Value>(
                     &request.ipc.clone().unwrap_or_default(),
                 ) {

--- a/modules/rpc/pkg/manifest.json
+++ b/modules/rpc/pkg/manifest.json
@@ -5,8 +5,8 @@
         "on_panic": "Restart",
         "request_networking": false,
         "request_messaging": [
-            "http_bindings:http_bindings:uqbar"
-            "app_tracker:app_tracker:uqbar"
+            "http_bindings:http_bindings:uqbar",
+            "app_tracker:app_tracker:uqbar",
 	        "http_server:sys:uqbar"
         ],
         "grant_messaging": []

--- a/modules/rpc/pkg/manifest.json
+++ b/modules/rpc/pkg/manifest.json
@@ -1,7 +1,7 @@
 [
     {
         "process_name": "rpc",
-        "process_wasm_path": "rpc.wasm",
+        "process_wasm_path": "/rpc.wasm",
         "on_panic": "Restart",
         "request_networking": false,
         "request_messaging": [

--- a/modules/rpc/pkg/manifest.json
+++ b/modules/rpc/pkg/manifest.json
@@ -5,7 +5,7 @@
         "on_panic": "Restart",
         "request_networking": false,
         "request_messaging": [
-            "http_bindings:sys:uqbar"
+            "http_bindings:http_bindings:uqbar"
         ],
         "grant_messaging": []
     }

--- a/modules/rpc/pkg/metadata.json
+++ b/modules/rpc/pkg/metadata.json
@@ -1,4 +1,4 @@
 {
-    "package": "sys",
+    "package": "rpc",
     "publisher": "uqbar"
 }

--- a/modules/rpc/src/lib.rs
+++ b/modules/rpc/src/lib.rs
@@ -88,7 +88,7 @@ impl Guest for Component {
 
         let bindings_address = Address {
             node: our.node.clone(),
-            process: ProcessId::from_str("http_bindings:sys:uqbar").unwrap(),
+            process: ProcessId::from_str("http_bindings:http_bindings:uqbar").unwrap(),
         };
 
         let http_endpoint_binding_requests: [(Address, Request, Option<Context>, Option<Payload>);

--- a/modules/terminal/pkg/manifest.json
+++ b/modules/terminal/pkg/manifest.json
@@ -1,7 +1,7 @@
 [
     {
         "process_name": "terminal",
-        "process_wasm_path": "terminal.wasm",
+        "process_wasm_path": "/terminal.wasm",
         "on_panic": "Restart",
         "request_networking": true,
         "request_messaging": [

--- a/modules/terminal/pkg/metadata.json
+++ b/modules/terminal/pkg/metadata.json
@@ -1,4 +1,4 @@
 {
-    "package": "sys",
+    "package": "terminal",
     "publisher": "uqbar"
 }

--- a/modules/terminal/src/lib.rs
+++ b/modules/terminal/src/lib.rs
@@ -54,6 +54,9 @@ fn parse_command(our_name: &str, line: String) {
             };
             //  TODO: why does this work but using the API below does not?
             //        Is it related to passing json in rather than a Serialize type?
+            //
+            print_to_terminal(0, &format!("terminal: {}\r", target_process));
+            print_to_terminal(0, &format!("terminal: {:?}\r", ProcessId::from_str(target_process.clone())));
             send_request(
                 &Address {
                     node: if target_node == "our" {
@@ -83,7 +86,7 @@ fn parse_command(our_name: &str, line: String) {
 
 impl Guest for Component {
     fn init(our: Address) {
-        assert_eq!(our.process.to_string(), "terminal:sys:uqbar");
+        assert_eq!(our.process.to_string(), "terminal:terminal:uqbar");
         print_to_terminal(1, &format!("terminal: start"));
         loop {
             let (source, message) = match receive() {

--- a/modules/terminal/src/lib.rs
+++ b/modules/terminal/src/lib.rs
@@ -56,7 +56,7 @@ fn parse_command(our_name: &str, line: String) {
             //        Is it related to passing json in rather than a Serialize type?
             //
             print_to_terminal(0, &format!("terminal: {}\r", target_process));
-            print_to_terminal(0, &format!("terminal: {:?}\r", ProcessId::from_str(target_process.clone())));
+            print_to_terminal(0, &format!("terminal: {:?}\r", ProcessId::from_str(target_process).unwrap_or(ProcessId::from_str(&format!("{}:sys:uqbar", target_process)).unwrap())));
             send_request(
                 &Address {
                     node: if target_node == "our" {

--- a/src/filesystem/mod.rs
+++ b/src/filesystem/mod.rs
@@ -16,8 +16,7 @@ pub async fn load_fs(
     home_directory_path: String,
     file_key: Vec<u8>,
     fs_config: FsConfig,
-    vfs_message_sender: MessageSender,
-) -> Result<(ProcessMap, Manifest), FsError> {
+) -> Result<(ProcessMap, Manifest, Vec<KernelMessage>), FsError> {
     // load/create fs directory, manifest + log if none.
     let fs_directory_path_str = format!("{}/fs", &home_directory_path);
 
@@ -66,7 +65,7 @@ pub async fn load_fs(
     let mut process_map: ProcessMap = HashMap::new();
 
     // get current processes' wasm_bytes handles. GetState(kernel)
-    match manifest.read(&kernel_process_id, None, None).await {
+    let vfs_messages = match manifest.read(&kernel_process_id, None, None).await {
         Err(_) => {
             //  bootstrap filesystem
             bootstrap(
@@ -74,17 +73,17 @@ pub async fn load_fs(
                 &kernel_process_id,
                 &mut process_map,
                 &mut manifest,
-                &vfs_message_sender,
             )
             .await
-            .expect("fresh bootstrap failed!");
+            .expect("fresh bootstrap failed!")
         }
         Ok(bytes) => {
             process_map = bincode::deserialize(&bytes).expect("state map deserialization error!");
+            vec![]
         }
-    }
+    };
 
-    Ok((process_map, manifest))
+    Ok((process_map, manifest, vfs_messages))
 }
 
 /// function run only upon fresh boot.
@@ -100,8 +99,7 @@ async fn bootstrap(
     kernel_process_id: &FileIdentifier,
     process_map: &mut ProcessMap,
     manifest: &mut Manifest,
-    vfs_message_sender: &MessageSender,
-) -> Result<()> {
+) -> Result<Vec<KernelMessage>> {
     println!("bootstrapping node...\r");
     const RUNTIME_MODULES: [(&str, bool); 8] = [
         ("filesystem:sys:uqbar", false),
@@ -109,7 +107,7 @@ async fn bootstrap(
         ("http_client:sys:uqbar", false),
         ("encryptor:sys:uqbar", false),
         ("net:sys:uqbar", false),
-        ("vfs:sys:uqbar", false),
+        ("vfs:sys:uqbar", true),
         ("kernel:sys:uqbar", false),
         ("eth_rpc:sys:uqbar", true), // TODO evaluate
     ];
@@ -144,6 +142,7 @@ async fn bootstrap(
                 public: runtime_module.1,
             });
     }
+    println!("fs bs: runtime process_map {:#?}\r", process_map);
 
     let packages: Vec<(String, zip::ZipArchive<std::io::Cursor<Vec<u8>>>)> =
         get_zipped_packages().await;
@@ -151,38 +150,37 @@ async fn bootstrap(
     // need to grant all caps at the end, after process_map has been filled in!
     let mut caps_to_grant = Vec::<(ProcessId, Capability)>::new();
 
+    let mut vfs_messages = Vec::new();
+
     for (package_name, mut package) in packages {
         println!("fs: handling package {package_name}...\r");
         // create a new package in VFS
-        vfs_message_sender
-            .send(KernelMessage {
-                id: rand::random(),
-                source: Address {
-                    node: our_name.to_string(),
-                    process: FILESYSTEM_PROCESS_ID.clone(),
-                },
-                target: Address {
-                    node: our_name.to_string(),
-                    process: VFS_PROCESS_ID.clone(),
-                },
-                rsvp: None,
-                message: Message::Request(Request {
-                    inherit: false,
-                    expects_response: None,
-                    ipc: Some(
-                        serde_json::to_string::<VfsRequest>(&VfsRequest {
-                            drive: package_name.clone(),
-                            action: VfsAction::New,
-                        })
-                        .unwrap(),
-                    ),
-                    metadata: None,
-                }),
-                payload: None,
-                signed_capabilities: None,
-            })
-            .await
-            .unwrap();
+        vfs_messages.push(KernelMessage {
+            id: rand::random(),
+            source: Address {
+                node: our_name.to_string(),
+                process: FILESYSTEM_PROCESS_ID.clone(),
+            },
+            target: Address {
+                node: our_name.to_string(),
+                process: VFS_PROCESS_ID.clone(),
+            },
+            rsvp: None,
+            message: Message::Request(Request {
+                inherit: false,
+                expects_response: None,
+                ipc: Some(
+                    serde_json::to_string::<VfsRequest>(&VfsRequest {
+                        drive: package_name.clone(),
+                        action: VfsAction::New,
+                    })
+                    .unwrap(),
+                ),
+                metadata: None,
+            }),
+            payload: None,
+            signed_capabilities: None,
+        });
         // for each file in package.zip, recursively through all dirs, send a newfile KM to VFS
         for i in 0..package.len() {
             let mut file = package.by_index(i).unwrap();
@@ -198,41 +196,38 @@ async fn bootstrap(
                 println!("fs: found file {}...\r", file_path);
                 let mut file_content = Vec::new();
                 file.read_to_end(&mut file_content).unwrap();
-                vfs_message_sender
-                    .send(KernelMessage {
-                        id: rand::random(),
-                        source: Address {
-                            node: our_name.to_string(),
-                            process: FILESYSTEM_PROCESS_ID.clone(),
-                        },
-                        target: Address {
-                            node: our_name.to_string(),
-                            process: VFS_PROCESS_ID.clone(),
-                        },
-                        rsvp: None,
-                        message: Message::Request(Request {
-                            inherit: false,
-                            expects_response: None,
-                            ipc: Some(
-                                serde_json::to_string::<VfsRequest>(&VfsRequest {
-                                    drive: package_name.clone(),
-                                    action: VfsAction::Add {
-                                        full_path: file_path,
-                                        entry_type: AddEntryType::NewFile,
-                                    },
-                                })
-                                .unwrap(),
-                            ),
-                            metadata: None,
-                        }),
-                        payload: Some(Payload {
-                            mime: None,
-                            bytes: file_content,
-                        }),
-                        signed_capabilities: None,
-                    })
-                    .await
-                    .unwrap();
+                vfs_messages.push(KernelMessage {
+                    id: rand::random(),
+                    source: Address {
+                        node: our_name.to_string(),
+                        process: FILESYSTEM_PROCESS_ID.clone(),
+                    },
+                    target: Address {
+                        node: our_name.to_string(),
+                        process: VFS_PROCESS_ID.clone(),
+                    },
+                    rsvp: None,
+                    message: Message::Request(Request {
+                        inherit: false,
+                        expects_response: None,
+                        ipc: Some(
+                            serde_json::to_string::<VfsRequest>(&VfsRequest {
+                                drive: package_name.clone(),
+                                action: VfsAction::Add {
+                                    full_path: file_path,
+                                    entry_type: AddEntryType::NewFile,
+                                },
+                            })
+                            .unwrap(),
+                        ),
+                        metadata: None,
+                    }),
+                    payload: Some(Payload {
+                        mime: None,
+                        bytes: file_content,
+                    }),
+                    signed_capabilities: None,
+                });
             }
         }
 
@@ -376,7 +371,7 @@ async fn bootstrap(
             .write(&kernel_process_id, &serialized_process_map)
             .await;
     }
-    Ok(())
+    Ok(vfs_messages)
 }
 
 /// go into /target folder and get all .zip package files

--- a/src/http_server/mod.rs
+++ b/src/http_server/mod.rs
@@ -660,7 +660,7 @@ async fn handler(
         },
         target: Address {
             node: our.clone(),
-            process: ProcessId::new(Some("http_bindings"), "sys", "uqbar"),
+            process: ProcessId::new(Some("http_bindings"), "http_bindings", "uqbar"),
         },
         rsvp: Some(Address {
             node: our.clone(),

--- a/src/kernel/mod.rs
+++ b/src/kernel/mod.rs
@@ -1896,7 +1896,8 @@ async fn make_event_loop(
                             match process_map.get(&kernel_message.source.process) {
                                 None => {}, // this should only get hit by kernel?
                                 Some(persisted) => {
-                                    if !persisted.capabilities.contains(&t::Capability {
+                                    if !persisted.public
+                                        && !persisted.capabilities.contains(&t::Capability {
                                         issuer: t::Address {
                                             node: our_name.clone(),
                                             process: kernel_message.target.process.clone(),

--- a/src/kernel/mod.rs
+++ b/src/kernel/mod.rs
@@ -1751,7 +1751,7 @@ async fn make_event_loop(
         );
         senders.insert(
             t::ProcessId::new(Some("vfs"), "sys", "uqbar"),
-            ProcessSender::Runtime(send_to_vfs.clone()),
+            ProcessSender::Runtime(send_to_vfs),
         );
 
         // each running process is stored in this map
@@ -2009,10 +2009,12 @@ async fn make_event_loop(
                         }
                         match senders.get(&kernel_message.target.process) {
                             Some(ProcessSender::Userspace(sender)) => {
+                                println!("el: sending to {}\r", kernel_message.target.process);
                                 // TODO: should this failing should crash kernel? probably not
                                 sender.send(Ok(kernel_message)).await.unwrap();
                             }
                             Some(ProcessSender::Runtime(sender)) => {
+                                println!("el: sending to {}\r", kernel_message.target.process);
                                 sender.send(kernel_message).await.expect("fatal: runtime module died");
                             }
                             None => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -373,12 +373,11 @@ async fn main() {
         )
     };
 
-    let (kernel_process_map, manifest) = filesystem::load_fs(
+    let (kernel_process_map, manifest, vfs_messages) = filesystem::load_fs(
         our.name.clone(),
         home_directory_path.clone(),
         file_key,
         fs_config,
-        vfs_message_sender.clone(),
     )
     .await
     .expect("fs load failed!");
@@ -466,6 +465,7 @@ async fn main() {
         print_sender.clone(),
         vfs_message_receiver,
         caps_oracle_sender.clone(),
+        vfs_messages,
     ));
     tasks.spawn(encryptor::encryptor(
         our.name.clone(),

--- a/src/types.rs
+++ b/src/types.rs
@@ -14,7 +14,7 @@ lazy_static::lazy_static! {
     pub static ref HTTP_CLIENT_PROCESS_ID: ProcessId = ProcessId::new(Some("http_client"), "sys", "uqbar");
     pub static ref HTTP_SERVER_PROCESS_ID: ProcessId = ProcessId::new(Some("http_server"), "sys", "uqbar");
     pub static ref KERNEL_PROCESS_ID: ProcessId = ProcessId::new(Some("kernel"), "sys", "uqbar");
-    pub static ref TERMINAL_PROCESS_ID: ProcessId = ProcessId::new(Some("terminal"), "sys", "uqbar");
+    pub static ref TERMINAL_PROCESS_ID: ProcessId = ProcessId::new(Some("terminal"), "terminal", "uqbar");
     pub static ref VFS_PROCESS_ID: ProcessId = ProcessId::new(Some("vfs"), "sys", "uqbar");
 }
 

--- a/src/vfs.rs
+++ b/src/vfs.rs
@@ -85,9 +85,13 @@ fn make_dir_name(full_path: &str) -> (String, String) {
 
 fn make_file_name(full_path: &str) -> (String, String) {
     let mut split_path: Vec<&str> = full_path.split("/").collect();
-    let name = split_path.pop().unwrap();
-    let path = format!("{}/", split_path.join("/"));
-    (name.into(), path)
+    let name = split_path.pop().unwrap_or("").to_string();
+    let path = if split_path.is_empty() {
+        String::new()
+    } else {
+        format!("{}/", split_path.join("/"))
+    };
+    (name, path)
 }
 
 fn make_error_message(

--- a/src/vfs.rs
+++ b/src/vfs.rs
@@ -225,7 +225,9 @@ async fn load_state_from_reboot(
     println!("vfs lsfr 4\r");
 }
 
-async fn noop_future() -> Option<DriveToVfs> { None }
+async fn noop_future() -> Option<DriveToVfs> {
+    None
+}
 
 pub async fn vfs(
     our_node: String,
@@ -252,7 +254,8 @@ pub async fn vfs(
         &send_to_loop,
         &mut recv_from_loop,
         &mut drive_to_vfs,
-    ).await;
+    )
+    .await;
 
     for vfs_message in vfs_messages {
         send_to_loop.send(vfs_message).await.unwrap();

--- a/src/vfs.rs
+++ b/src/vfs.rs
@@ -628,7 +628,11 @@ async fn match_request(
                     let Some(mut parent_entry) = vfs.key_to_entry.remove(&parent_key) else {
                         panic!("");
                     };
-                    let EntryType::Dir { children: ref mut parent_children, .. } = parent_entry.entry_type else {
+                    let EntryType::Dir {
+                        children: ref mut parent_children,
+                        ..
+                    } = parent_entry.entry_type
+                    else {
                         panic!("");
                     };
                     let key = Key::Dir { id: rand::random() };
@@ -724,7 +728,11 @@ async fn match_request(
                     let Some(mut parent_entry) = vfs.key_to_entry.remove(&parent_key) else {
                         panic!("");
                     };
-                    let EntryType::Dir { children: ref mut parent_children, .. } = parent_entry.entry_type else {
+                    let EntryType::Dir {
+                        children: ref mut parent_children,
+                        ..
+                    } = parent_entry.entry_type
+                    else {
                         panic!("");
                     };
                     let key = Key::File { id: hash };
@@ -782,7 +790,11 @@ async fn match_request(
                     let Some(mut parent_entry) = vfs.key_to_entry.remove(&parent_key) else {
                         panic!("");
                     };
-                    let EntryType::Dir { children: ref mut parent_children, .. } = parent_entry.entry_type else {
+                    let EntryType::Dir {
+                        children: ref mut parent_children,
+                        ..
+                    } = parent_entry.entry_type
+                    else {
                         panic!("");
                     };
                     let key = Key::File { id: hash };
@@ -878,10 +890,15 @@ async fn match_request(
                             let Some(parent_key) = vfs.path_to_key.remove(&parent_path) else {
                                 panic!("");
                             };
-                            let Some(mut parent_entry) = vfs.key_to_entry.remove(&parent_key) else {
+                            let Some(mut parent_entry) = vfs.key_to_entry.remove(&parent_key)
+                            else {
                                 panic!("");
                             };
-                            let EntryType::Dir { children: ref mut parent_children, .. } = parent_entry.entry_type else {
+                            let EntryType::Dir {
+                                children: ref mut parent_children,
+                                ..
+                            } = parent_entry.entry_type
+                            else {
                                 panic!("");
                             };
                             let key = Key::File { id: hash };

--- a/src/vfs.rs
+++ b/src/vfs.rs
@@ -225,10 +225,6 @@ async fn load_state_from_reboot(
     println!("vfs lsfr 4\r");
 }
 
-async fn noop_future() -> Option<DriveToVfs> {
-    None
-}
-
 pub async fn vfs(
     our_node: String,
     send_to_loop: MessageSender,


### PR DESCRIPTION
@dr-frmr made some changes to build.rs (to build one-deep apps like key_value), filesystem bootstrap (to explicitly place files in root dir in VFS [behavior before this PR was that `foo.wasm` would properly be added to `/` but `foo/bar.wasm` would not be; intended behavior was that `/` must always be prepended and that is now properly enforced as of 872b15f]), and kernel (public -> can receive messages)

PTAL