### PR TITLE
fshotfix

### DIFF
--- a/src/filesystem/manifest.rs
+++ b/src/filesystem/manifest.rs
@@ -413,7 +413,9 @@ impl Manifest {
 
         while let Some(chunk) = chunks.next() {
             if memory_buffer.len() + chunk.len() > self.memory_limit {
+                manifest.insert(file.clone(), in_memory_file);
                 self.flush_to_wal(&mut manifest, &mut memory_buffer).await?;
+                in_memory_file = manifest.get(file).unwrap().clone();
             }
 
             self.write_chunk(
@@ -804,7 +806,9 @@ impl Manifest {
                 .copy_from_slice(data_to_write);
 
             if memory_buffer.len() + chunk_data.len() > self.memory_limit {
+                manifest.insert(file_id.clone(), file);
                 self.flush_to_wal(&mut manifest, &mut memory_buffer).await?;
+                file = manifest.get(file_id).unwrap().clone();
             }
 
             self.write_chunk(


### PR DESCRIPTION
note: 
I'm going to separate out the parts of manifest more, specifically the locks and where they happen. the issue before this fix was, with big files, flush_to_wal would update positions, but we would ignore them in our local write() functions, and then promptly finally overwrite them for the specific file.

let's see what can be done with mutable reference passing, and what needs explicit locks.