### PR TITLE
move redb & rusqlite deps into Cargo.toml

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@nightly
       - uses: mbrobbel/rustfmt-check@master
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,6 +8,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@nightly
+        with:
+          components: rustfmt
       - uses: mbrobbel/rustfmt-check@master
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -7,10 +7,7 @@ Last updated: 10/16/23
 # Clone the repo.
 
 git clone git@github.com:uqbar-dao/uqbar.git
-git clone git@github.com:uqbar-dao/redb.git
-git clone git@github.com:uqbar-dao/rusqlite.git
 
-Make sure the two repos are next to each other in your directory structure.
 
 # Get some stuff so we can build wasm.
 
@@ -22,13 +19,17 @@ rustup target add wasm32-wasi --toolchain nightly
 cargo install cargo-wasi
 cargo install --git https://github.com/bytecodealliance/cargo-component --locked cargo-component
 
+
 # Initialize submodules, in particular the register app
+
 git submodule update --init --recursive
 # Build the register app
 cd src/register && ./build_all.sh && cd ../..
 
+
 # Build the runtime, along with a number of booted-at-startup WASM modules including terminal and key_value
 # OPTIONAL: --release flag
+
 cargo +nightly build --release
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Last updated: 10/16/23
+Last updated: 11/01/23
 ## Setup
 
 ### Building components

--- a/build.rs
+++ b/build.rs
@@ -46,8 +46,12 @@ fn build_app(target_path: &str, name: &str, parent_pkg_path: Option<&str>) {
     .unwrap_or(true)
     {
         println!("cargo:warning=wit outdated, rebuilding");
-        run_command(Command::new("cp").args(&["wit/uqbar.wit", &format!("{}/wit", target_path)]))
-            .unwrap();
+        run_command(Command::new("cp").args(&[
+            "-r",
+            &format!("{}/wit", pwd.display()),
+            &format!("{}/wit", target_path),
+        ]))
+        .unwrap();
         // create target/bindings directory
         fs::create_dir_all(&format!("{}/target/bindings/{}", target_path, name,)).unwrap();
         // copy newly-made target.wasm into target/bindings

--- a/modules/key_value/key_value_worker/Cargo.lock
+++ b/modules/key_value/key_value_worker/Cargo.lock
@@ -330,6 +330,7 @@ dependencies = [
 [[package]]
 name = "redb"
 version = "1.2.0"
+source = "git+https://github.com/uqbar-dao/redb?rev=8e192d9#8e192d945295e1ddd331003bae215cd8d1564c4b"
 dependencies = [
  "libc",
  "pyo3-build-config",

--- a/modules/key_value/key_value_worker/Cargo.toml
+++ b/modules/key_value/key_value_worker/Cargo.toml
@@ -14,8 +14,8 @@ lto = true
 anyhow = "1.0"
 bincode = "1.3.3"
 cargo-component-bindings = { git = "https://github.com/bytecodealliance/cargo-component" }
-redb = { path = "../../../../redb" }
-serde = {version = "1.0", features = ["derive"] }
+redb = { git = "https://github.com/uqbar-dao/redb", rev = "8e192d9" }
+serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 thiserror = "1.0"
 wit-bindgen = { version = "0.11.0", default_features = false }

--- a/modules/sqlite/sqlite_worker/Cargo.lock
+++ b/modules/sqlite/sqlite_worker/Cargo.lock
@@ -200,6 +200,7 @@ checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
 [[package]]
 name = "libsqlite3-sys"
 version = "0.26.0"
+source = "git+https://github.com/uqbar-dao/rusqlite?rev=fa6ed84#fa6ed843b65f7dd78d53a1b74c7e5095d71c2bd4"
 dependencies = [
  "cc",
  "pkg-config",
@@ -305,6 +306,7 @@ dependencies = [
 [[package]]
 name = "rusqlite"
 version = "0.29.0"
+source = "git+https://github.com/uqbar-dao/rusqlite?rev=fa6ed84#fa6ed843b65f7dd78d53a1b74c7e5095d71c2bd4"
 dependencies = [
  "bitflags 2.4.0",
  "fallible-iterator",

--- a/modules/sqlite/sqlite_worker/Cargo.toml
+++ b/modules/sqlite/sqlite_worker/Cargo.toml
@@ -15,7 +15,7 @@ anyhow = "1.0"
 bincode = "1.3.3"
 cargo-component-bindings = { git = "https://github.com/bytecodealliance/cargo-component" }
 rmp-serde = "1.1"
-rusqlite = { path = "../../../../rusqlite/", features = ["bundled", "wasm32-wasi-vfs"] }
+rusqlite = { git = "https://github.com/uqbar-dao/rusqlite", rev = "fa6ed84", features = ["bundled", "wasm32-wasi-vfs"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 thiserror = "1.0"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "nightly"


### PR DESCRIPTION
Better than submodules: use Cargo.toml `git = foo, rev = bar`.