### PR TITLE
sqlite transactions

### DIFF
--- a/modules/sqlite/sqlite/src/lib.rs
+++ b/modules/sqlite/sqlite/src/lib.rs
@@ -147,7 +147,7 @@ fn handle_message (
                         .ipc_bytes(ipc)
                         .send()?;
                 },
-                sq::SqliteMessage::Write { ref db, ref statement } => {
+                sq::SqliteMessage::Write { ref db, ref statement, ref tx_id } => {
                     let first_word = statement
                         .split_whitespace()
                         .next()
@@ -168,6 +168,12 @@ fn handle_message (
                         return Err(sq::SqliteError::NotAReadKeyword.into())
                     }
                     forward_if_have_cap(our, "read", db, ipc, db_to_process)?;
+                },
+                sq::SqliteMessage::StartTransaction { ref db, ref tx_id } => {
+                    forward_if_have_cap(our, "write", db, ipc, db_to_process)?;
+                },
+                sq::SqliteMessage::Commit { ref db, ref tx_id } => {
+                    forward_if_have_cap(our, "write", db, ipc, db_to_process)?;
                 },
             }
 

--- a/modules/sqlite/sqlite/src/lib.rs
+++ b/modules/sqlite/sqlite/src/lib.rs
@@ -169,9 +169,6 @@ fn handle_message (
                     }
                     forward_if_have_cap(our, "read", db, ipc, db_to_process)?;
                 },
-                sq::SqliteMessage::StartTransaction { ref db, ref tx_id } => {
-                    forward_if_have_cap(our, "write", db, ipc, db_to_process)?;
-                },
                 sq::SqliteMessage::Commit { ref db, ref tx_id } => {
                     forward_if_have_cap(our, "write", db, ipc, db_to_process)?;
                 },

--- a/modules/sqlite/sqlite_types.rs
+++ b/modules/sqlite/sqlite_types.rs
@@ -3,8 +3,10 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Serialize, Deserialize)]
 pub enum SqliteMessage {
     New { db: String },
-    Write { db: String, statement: String },
+    Write { db: String, statement: String, tx_id: Option<u64> },
     Read { db: String, query: String },
+    StartTransaction { db: String, tx_id: u64 }, // generate in sql module instead?
+    Commit { db: String, tx_id: u64 },
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -31,6 +33,8 @@ pub enum SqliteError {
     DbDoesNotExist,
     #[error("DbAlreadyExists")]
     DbAlreadyExists,
+    #[error("NoTx")]
+    NoTx,
     #[error("NoCap")]
     NoCap,
     #[error("RejectForeign")]

--- a/modules/sqlite/sqlite_types.rs
+++ b/modules/sqlite/sqlite_types.rs
@@ -5,7 +5,6 @@ pub enum SqliteMessage {
     New { db: String },
     Write { db: String, statement: String, tx_id: Option<u64> },
     Read { db: String, query: String },
-    StartTransaction { db: String, tx_id: u64 }, // generate in sql module instead?
     Commit { db: String, tx_id: u64 },
 }
 

--- a/modules/sqlite/sqlite_worker/src/lib.rs
+++ b/modules/sqlite/sqlite_worker/src/lib.rs
@@ -371,15 +371,15 @@ fn handle_message(
                         None => {
                             let flags = rusqlite::OpenFlags::default();
                             *conn = Some(rusqlite::Connection::open_with_flags_and_vfs(
-                                    format!(
-                                        "{}:{}:/{}.sql",
-                                        our.node,
-                                        vfs_drive,
-                                        db,
-                                    ),
-                                    flags,
-                                    "uqbar",
-                                )?);
+                                format!(
+                                    "{}:{}:/{}.sql",
+                                    our.node,
+                                    vfs_drive,
+                                    db,
+                                ),
+                                flags,
+                                "uqbar",
+                            )?);
                         },
                     }
                 },
@@ -477,7 +477,6 @@ impl Guest for Component {
 
         let mut conn: Option<rusqlite::Connection> = None;
         let mut txs: HashMap<u64, Vec<(String, Vec<sq::SqlValue>)>> = HashMap::new();
-
 
         grant_messaging(
             &our,


### PR DESCRIPTION
~~This is still in Draft phase.~~
we good.

Reason being, how rusqlite handles lifetimes in it's structs.

Essentially, when creating a transaction, it's expected it doesn't "outlive" the original Connection it references. Usually fine, if code looks something like this:

let conn = create_connection();
let tx = conn.tx()

tx.do_things()
tx.commit()
return, tx goes out of scope. 

In our case, we might want the tx to span several received messages, so it should be stored in mem.

**Things I'm trying**
refcell/arc
explicit lifetimes &'a
new connection every message?
