### PR TITLE
allowed unused mut

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -228,7 +228,8 @@ async fn main() {
 
     // the boolean flag determines whether the runtime module is *public* or not,
     // where public means that any process can always message it.
-    let runtime_extensions = vec![
+    #[allow(unused_mut)]
+    let mut runtime_extensions = vec![
         (
             ProcessId::new(Some("filesystem"), "sys", "uqbar"),
             fs_message_sender,


### PR DESCRIPTION
`mut` is needed if `llm` feature is enabled. If not then you get a warning that you don't need the `mut` because the `llm` code doesn't get compiled. Added a line of code to bypass this warning so that no one gets rid of it