### PR TITLE
websockets fixed

### DIFF
--- a/src/http/server.rs
+++ b/src/http/server.rs
@@ -143,7 +143,15 @@ async fn serve(
              send_to_loop: MessageSender,
              print_tx: PrintSender| {
                 ws_connection.on_upgrade(move |ws: WebSocket| async move {
-                    maintain_websocket(ws, our, jwt_secret_bytes, ws_senders, send_to_loop, print_tx).await
+                    maintain_websocket(
+                        ws,
+                        our,
+                        jwt_secret_bytes,
+                        ws_senders,
+                        send_to_loop,
+                        print_tx,
+                    )
+                    .await
                 })
             },
         );

--- a/src/http/server.rs
+++ b/src/http/server.rs
@@ -25,7 +25,7 @@ type HttpSender = tokio::sync::oneshot::Sender<(HttpResponse, Vec<u8>)>;
 /// mapping from an open websocket connection to a channel that will ingest
 /// WebSocketPush messages from the app that handles the connection, and
 /// send them to the connection.
-type WebSocketSenders = Arc<DashMap<u64, (ProcessId, WebSocketSender)>>;
+type WebSocketSenders = Arc<DashMap<u32, (ProcessId, WebSocketSender)>>;
 type WebSocketSender = tokio::sync::mpsc::Sender<warp::ws::Message>;
 
 type PathBindings = Arc<RwLock<Router<BoundPath>>>;
@@ -424,8 +424,7 @@ async fn maintain_websocket(
         return;
     }
 
-    let max_js_safe_integer: u64 = (1u64 << 53) - 1;
-    let ws_channel_id: u64 = rand::random::<u64>() & max_js_safe_integer;
+    let ws_channel_id: u32 = rand::random();
     let (ws_sender, mut ws_receiver) = tokio::sync::mpsc::channel(100);
     ws_senders.insert(ws_channel_id, (owner_process.clone(), ws_sender));
 
@@ -510,7 +509,7 @@ async fn maintain_websocket(
 }
 
 async fn websocket_close(
-    channel_id: u64,
+    channel_id: u32,
     process: ProcessId,
     ws_senders: &WebSocketSenders,
     send_to_loop: &MessageSender,

--- a/src/http/types.rs
+++ b/src/http/types.rs
@@ -74,17 +74,17 @@ pub enum HttpServerAction {
     /// Processes will RECEIVE this kind of request when a client connects to them.
     /// If a process does not want this websocket open, they can respond with an
     /// [`enum@HttpServerAction::WebSocketClose`] message.
-    WebSocketOpen(u64),
+    WebSocketOpen(u32),
     /// Processes can both SEND and RECEIVE this kind of request.
     /// When sent, expects a payload containing the WebSocket message bytes to send.
     WebSocketPush {
-        channel_id: u64,
+        channel_id: u32,
         message_type: WsMessageType,
     },
     /// Processes can both SEND and RECEIVE this kind of request. Sending will
     /// close a socket the process controls. Receiving will indicate that the
     /// client closed the socket.
-    WebSocketClose(u64),
+    WebSocketClose(u32),
 }
 
 /// The possible message types for WebSocketPush. Ping and Pong are limited to 125 bytes
@@ -129,7 +129,7 @@ pub struct WsRegister {
 /// Structure sent from this server to client websocket upon opening a new connection.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct WsRegisterResponse {
-    pub channel_id: u64,
+    pub channel_id: u32,
     // TODO symmetric key exchange here
 }
 


### PR DESCRIPTION
The max JS integer is often well below a random rust `u64` value. I altered the range so that channel_ids are always less than the max JS number value