### PR TITLE
http-client-fix

### DIFF
--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -148,12 +148,12 @@ async fn handle_message(
                     message: Message::Response((
                         Response {
                             inherit: false,
-                            ipc: serde_json::to_vec::<Result<HttpResponse, HttpClientError>>(
-                                &Ok(HttpResponse {
+                            ipc: serde_json::to_vec::<Result<HttpResponse, HttpClientError>>(&Ok(
+                                HttpResponse {
                                     status: response.status().as_u16(),
                                     headers: serialize_headers(response.headers()),
-                                }),
-                            )
+                                },
+                            ))
                             .unwrap(),
                             metadata: None,
                         },

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -136,38 +136,36 @@ async fn handle_message(
 
     match client.execute(request).await {
         Ok(response) => {
-            if expects_response.is_some() {
-                let _ = send_to_loop
-                    .send(KernelMessage {
-                        id,
-                        source: Address {
-                            node: our.to_string(),
-                            process: ProcessId::new(Some("http_client"), "sys", "uqbar"),
+            let _ = send_to_loop
+                .send(KernelMessage {
+                    id,
+                    source: Address {
+                        node: our.to_string(),
+                        process: ProcessId::new(Some("http_client"), "sys", "uqbar"),
+                    },
+                    target,
+                    rsvp: None,
+                    message: Message::Response((
+                        Response {
+                            inherit: false,
+                            ipc: serde_json::to_vec::<Result<HttpResponse, HttpClientError>>(
+                                &Ok(HttpResponse {
+                                    status: response.status().as_u16(),
+                                    headers: serialize_headers(response.headers()),
+                                }),
+                            )
+                            .unwrap(),
+                            metadata: None,
                         },
-                        target,
-                        rsvp: None,
-                        message: Message::Response((
-                            Response {
-                                inherit: false,
-                                ipc: serde_json::to_vec::<Result<HttpResponse, HttpClientError>>(
-                                    &Ok(HttpResponse {
-                                        status: response.status().as_u16(),
-                                        headers: serialize_headers(response.headers()),
-                                    }),
-                                )
-                                .unwrap(),
-                                metadata: None,
-                            },
-                            None,
-                        )),
-                        payload: Some(Payload {
-                            mime: None,
-                            bytes: response.bytes().await.unwrap_or_default().to_vec(),
-                        }),
-                        signed_capabilities: None,
-                    })
-                    .await;
-            }
+                        None,
+                    )),
+                    payload: Some(Payload {
+                        mime: None,
+                        bytes: response.bytes().await.unwrap_or_default().to_vec(),
+                    }),
+                    signed_capabilities: None,
+                })
+                .await;
         }
         Err(e) => {
             make_error_message(


### PR DESCRIPTION
http_client was not properly sending responses if it was meant to be routed to the `rsvp`

It is worth noting that since `inherit`/`rsvp` aresomewhat tricky to understand, and because they are rarely used in app code, this bug might exist in a fair number of places, and could go undiscovered until someone tries to make a long chain of requests with `inherit=true`, `expects-response=false`