### PR TITLE
fix spawn and vfs messaging caps

### DIFF
--- a/modules/tester/test_runner/src/lib.rs
+++ b/modules/tester/test_runner/src/lib.rs
@@ -42,7 +42,7 @@ fn handle_message(our: &Address) -> anyhow::Result<()> {
                     let response = Request::new()
                         .target(make_vfs_address(&our)?)
                         .ipc(serde_json::to_vec(&kt::VfsRequest {
-                            path: "/tester:uqbar/pkg".into(),
+                            path: "/tester:uqbar/tests".into(),
                             action: kt::VfsAction::ReadDir,
                         })?)
                         .send_and_await_response(test_timeout)?
@@ -54,17 +54,17 @@ fn handle_message(our: &Address) -> anyhow::Result<()> {
                     let kt::VfsResponse::ReadDir(children) =
                         serde_json::from_slice(&vfs_ipc)?
                     else {
+                        wit::print_to_terminal(
+                            0,
+                            &format!(
+                                "{:?}",
+                                serde_json::from_slice::<serde_json::Value>(&vfs_ipc)?,
+                            ),
+                        );
                         panic!("")
                     };
-                    let mut children: HashSet<_> = children.into_iter().collect();
-                    children.remove("/manifest.json");
-                    children.remove("/metadata.json");
-                    children.remove("/tester.wasm");
-                    children.remove("/test_runner.wasm");
 
                     wit::print_to_terminal(0, &format!("test_runner: running {:?}...", children));
-
-                    // todo: are children returned as absolute paths. 
 
                     for child in &children {
                         let child_process_id = match spawn(

--- a/modules/tester/tester/src/lib.rs
+++ b/modules/tester/tester/src/lib.rs
@@ -31,7 +31,6 @@ fn handle_message(
     _messages: &mut Messages,
     node_names: &mut Vec<String>,
 ) -> anyhow::Result<()> {
-    println!("handle_message");
     let Ok(message) = await_message() else {
         return Ok(());
     };
@@ -113,11 +112,20 @@ fn init(our: Address) {
 
     // orchestrate tests using external scripts
     //  -> must give drive cap to rpc
+    let _ = Request::new()
+        .target(make_vfs_address(&our).unwrap())
+        .ipc(serde_json::to_vec(&kt::VfsRequest {
+            path: "/tester:uqbar/tests".into(),
+            action: kt::VfsAction::CreateDrive,
+        }).unwrap())
+        .send_and_await_response(5)
+        .unwrap()
+        .unwrap();
     let drive_cap = get_capability(
         &make_vfs_address(&our).unwrap(),
         &serde_json::to_string(&serde_json::json!({
             "kind": "write",
-            "drive": "/tester:uqbar/pkg",
+            "drive": "/tester:uqbar/tests",
         }))
         .expect("couldn't serialize"),
     )

--- a/src/kernel/mod.rs
+++ b/src/kernel/mod.rs
@@ -886,6 +886,7 @@ pub async fn kernel(
                     // kernel and filesystem can ALWAYS message any local process
                     if kernel_message.source.process != *KERNEL_PROCESS_ID
                         && kernel_message.source.process != *STATE_PROCESS_ID
+                        && kernel_message.source.process != *VFS_PROCESS_ID
                     {
                         let Some(persisted_source) = process_map.get(&kernel_message.source.process) else {
                             continue

--- a/src/kernel/standard_host.rs
+++ b/src/kernel/standard_host.rs
@@ -185,18 +185,6 @@ impl StandardHost for process::ProcessWasi {
             node: self.process.metadata.our.node.clone(),
             process: VFS_PROCESS_ID.en_wit(),
         };
-        // TODO: note, drive could just be your basic process maybe.
-        let path = format!(
-            "/{}/{}/{}",
-            self.process.metadata.our.process.to_string(),
-            self.process.metadata.our.process.package(),
-            wasm_path
-        );
-        // let our_drive_name = [
-        //     self.process.metadata.our.process.package(),
-        //     self.process.metadata.our.process.publisher(),
-        // ]
-        // .join(":");
         let Ok(Ok((_, hash_response))) = process::send_and_await_response(
             self,
             None,
@@ -205,7 +193,7 @@ impl StandardHost for process::ProcessWasi {
                 inherit: false,
                 expects_response: Some(5),
                 ipc: serde_json::to_vec(&t::VfsRequest {
-                    path: path.clone(),
+                    path: wasm_path.clone(),
                     action: t::VfsAction::Read,
                 })
                 .unwrap(),
@@ -260,7 +248,7 @@ impl StandardHost for process::ProcessWasi {
                 expects_response: Some(5), // TODO evaluate
                 ipc: serde_json::to_vec(&t::KernelCommand::InitializeProcess {
                     id: new_process_id.clone(),
-                    wasm_bytes_handle: path,
+                    wasm_bytes_handle: wasm_path,
                     on_exit: t::OnExit::de_wit(on_exit),
                     initial_capabilities: match capabilities {
                         wit::Capabilities::None => HashSet::new(),


### PR DESCRIPTION
`spawn()` and vfs caps fix are in src/kernel.

Please try this out with latest uqdev & core-tests if you have the chance. boot-fake-nodes, run-tests, etc, all work on my system.

@bitful-pannul : please update the [core-tests](https://github.com/uqbar-dao/core_tests) sqlite and key_value tests when you have a chance to test your sqlite & key_value modules.