### PR TITLE
Make wit version explicit per-process for backcompat

### DIFF
--- a/src/kernel/mod.rs
+++ b/src/kernel/mod.rs
@@ -17,6 +17,8 @@ mod standard_host;
 
 const PROCESS_CHANNEL_CAPACITY: usize = 100;
 
+const DEFAULT_WIT_VERSION: u32 = 0;
+
 type ProcessMessageSender =
     tokio::sync::mpsc::Sender<Result<t::KernelMessage, t::WrappedSendError>>;
 type ProcessMessageReceiver =
@@ -143,6 +145,7 @@ async fn handle_kernel_request(
         t::KernelCommand::InitializeProcess {
             id,
             wasm_bytes_handle,
+            wit_version,
             on_exit,
             initial_capabilities,
             public,
@@ -249,6 +252,7 @@ async fn handle_kernel_request(
                     process_id: id,
                     persisted: t::PersistedProcess {
                         wasm_bytes_handle,
+                        wit_version,
                         on_exit,
                         capabilities: valid_capabilities,
                         public,
@@ -615,6 +619,10 @@ async fn start_process(
             process: id.clone(),
         },
         wasm_bytes_handle: process_metadata.persisted.wasm_bytes_handle.clone(),
+        wit_version: process_metadata
+            .persisted
+            .wit_version
+            .unwrap_or(DEFAULT_WIT_VERSION),
         on_exit: process_metadata.persisted.on_exit.clone(),
         public: process_metadata.persisted.public,
     };

--- a/src/kernel/process.rs
+++ b/src/kernel/process.rs
@@ -563,6 +563,7 @@ pub async fn make_process_loop(
                             ipc: serde_json::to_vec(&t::KernelCommand::InitializeProcess {
                                 id: metadata.our.process.clone(),
                                 wasm_bytes_handle: metadata.wasm_bytes_handle,
+                                wit_version: Some(metadata.wit_version),
                                 on_exit: metadata.on_exit,
                                 initial_capabilities,
                                 public: metadata.public,

--- a/src/kernel/standard_host.rs
+++ b/src/kernel/standard_host.rs
@@ -257,6 +257,7 @@ impl StandardHost for process::ProcessWasi {
                 ipc: serde_json::to_vec(&t::KernelCommand::InitializeProcess {
                     id: new_process_id.clone(),
                     wasm_bytes_handle: wasm_path,
+                    wit_version: Some(self.process.metadata.wit_version),
                     on_exit: t::OnExit::de_wit(on_exit),
                     initial_capabilities: match capabilities {
                         wit::Capabilities::None => HashSet::new(),

--- a/src/state.rs
+++ b/src/state.rs
@@ -331,6 +331,7 @@ async fn bootstrap(
         .entry(ProcessId::from_str("kernel:sys:uqbar").unwrap())
         .or_insert(PersistedProcess {
             wasm_bytes_handle: "".into(),
+            wit_version: None,
             on_exit: OnExit::Restart,
             capabilities: runtime_caps.clone(),
             public: false,
@@ -339,6 +340,7 @@ async fn bootstrap(
         .entry(ProcessId::from_str("net:sys:uqbar").unwrap())
         .or_insert(PersistedProcess {
             wasm_bytes_handle: "".into(),
+            wit_version: None,
             on_exit: OnExit::Restart,
             capabilities: runtime_caps.clone(),
             public: false,
@@ -348,6 +350,7 @@ async fn bootstrap(
             .entry(runtime_module.0)
             .or_insert(PersistedProcess {
                 wasm_bytes_handle: "".into(),
+                wit_version: None,
                 on_exit: OnExit::Restart,
                 capabilities: runtime_caps.clone(),
                 public: runtime_module.2,
@@ -538,6 +541,7 @@ async fn bootstrap(
                 ProcessId::new(Some(&entry.process_name), package_name, package_publisher),
                 PersistedProcess {
                     wasm_bytes_handle,
+                    wit_version: None,
                     on_exit: entry.on_exit,
                     capabilities: requested_caps,
                     public: public_process,

--- a/src/types.rs
+++ b/src/types.rs
@@ -736,6 +736,7 @@ pub struct IdentityTransaction {
 pub struct ProcessMetadata {
     pub our: Address,
     pub wasm_bytes_handle: String,
+    pub wit_version: u32,
     pub on_exit: OnExit,
     pub public: bool,
 }
@@ -812,6 +813,7 @@ pub enum KernelCommand {
     InitializeProcess {
         id: ProcessId,
         wasm_bytes_handle: String,
+        wit_version: Option<u32>,
         on_exit: OnExit,
         initial_capabilities: HashSet<SignedCapability>,
         public: bool,
@@ -876,6 +878,7 @@ pub type ProcessMap = HashMap<ProcessId, PersistedProcess>;
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct PersistedProcess {
     pub wasm_bytes_handle: String,
+    pub wit_version: Option<u32>,
     pub on_exit: OnExit,
     pub capabilities: HashSet<Capability>,
     pub public: bool, // marks if a process allows messages from any process


### PR DESCRIPTION
This is a breaking change which adds a field `wit_version` to various areas in the kernel, allowing the kernel to support multiple wit versions in the future.

Only the major version number is kept, as minor versions and patches will not be permitted to include breaking changes. The major version can be switched on to lead to different kernel logic in the event of backwards-incompatible changes to any part of the kernel in future releases.