### PR TITLE
http-server: fix deadlock

### DIFF
--- a/src/http/server.rs
+++ b/src/http/server.rs
@@ -514,6 +514,9 @@ async fn http_handler(
         }
     }
 
+    // unlock to avoid deadlock with .write()s
+    drop(path_bindings);
+
     let timeout_duration = tokio::time::Duration::from_secs(HTTP_SELF_IMPOSED_TIMEOUT);
     let result = tokio::time::timeout(timeout_duration, response_receiver).await;
 


### PR DESCRIPTION
To reproduce:

```
# Get kit next-release
cargo install --git https://github.com/uqbar-dao/kit --branch next-release

# Get core_tests
git clone git@github.com:uqbar-dao/core_tests.git
cd core_tests

# Run core_tests here vs on next-release:
kit t
```

Success looks like

```
Mon 1/15 21:18 http_server: running on port 8081
second.nec > http_server: running on port 8080
Mon 1/15 21:18 chess by nectar: start
Mon 1/15 21:18 tester: begin
Mon 1/15 21:18 ndns_indexer: indexing on contract address 0x942A69Cc3dd5d9a87c35f13ebA444adc00934B0F
Mon 1/15 21:18 main:app_store:nectar: running
Mon 1/15 21:18 tester: begin
Mon 1/15 21:18 ndns_indexer: indexing on contract address 0x942A69Cc3dd5d9a87c35f13ebA444adc00934B0F
Mon 1/15 21:18 main:app_store:nectar: running
Mon 1/15 21:18 chess by nectar: start
first.nec > Done setting up node "/home/nick/git/core-tests/home/first" on port 8080.
Setting up node "/home/nick/git/core-tests/home/second"...
Done setting up node "/home/nick/git/core-tests/home/second" on port 8081.
Loading setup packages...
chat:nectar
Successfully installed package chat:nectar on node at http://localhost:8080
Done loading setup packages.
Loading setup packages...
chat:nectar
Mon 1/15 21:18 chat: begin
first.nec > Successfully installed package chat:nectar on node at http://localhost:8081
Done loading setup packages.
Loading tests...
Mon 1/15 21:18 chat: begin
second.nec > Done loading tests.
Mon 1/15 21:18 tester: got Run
second.nec > Running tests...
Mon 1/15 21:18 tester: got Run
Mon 1/15 21:18 "first.nec@13549185859273644945:tester:nectar"@test_runner: begin
Mon 1/15 21:18 test_runner: got Run
Mon 1/15 21:18 test_runner: running [DirEntry { path: "tester:nectar/tests/chat_test.wasm", file_type: File }]...
Mon 1/15 21:18 chat_test: begin
Mon 1/15 21:18 chat_test: a
Mon 1/15 21:18 chat_test: b
Mon 1/15 21:18 chat|first.nec: hello
Mon 1/15 21:18 chat_test: c
Mon 1/15 21:18 test_runner: done running [DirEntry { path: "tester:nectar/tests/chat_test.wasm", file_type: File }]
first.nec > PASS
Cleaning up "/home/nick/git/core-tests/home/first"...
nectar: disabled raw mode successfully: Ok(false)

graceful exit
Done cleaning up "/home/nick/git/core-tests/home/first".
Cleaning up "/home/nick/git/core-tests/home/second"...
nectar: disabled raw mode successfully: Ok(false)

graceful exit
Done cleaning up "/home/nick/git/core-tests/home/second".
```

Failure looks like a your terminal is not released to you; you may see a crash in chess; you may see a "failed to bind" error; you will not see a PASS or any `graceful exit`s: a deadlock has occurred.

On my linux machine I never saw the deadlock. On my 2017 macOS I saw the deadlock at least once every 5 runs. Here, I haven't seen it for 30+ runs.