### PR TITLE
app_store: add sqlite & kv perms so they can be requested

### DIFF
--- a/modules/app_store/pkg/manifest.json
+++ b/modules/app_store/pkg/manifest.json
@@ -15,6 +15,8 @@
             "eth:distro:sys",
             "sqlite:distro:sys",
             "kv:distro:sys",
+            "chess:chess:sys",
+            "kns_indexer:kns_indexer:sys",
             {
                 "process": "vfs:distro:sys",
                 "params": {

--- a/modules/app_store/pkg/manifest.json
+++ b/modules/app_store/pkg/manifest.json
@@ -13,6 +13,8 @@
             "vfs:distro:sys",
             "kernel:distro:sys",
             "eth:distro:sys",
+            "sqlite:distro:sys",
+            "kv:distro:sys",
             {
                 "process": "vfs:distro:sys",
                 "params": {


### PR DESCRIPTION
Without this change, packages started by app_store cannot themselves request these caps.

Any others we should add here?