### PR TITLE
kernel: remove temp_dir

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ dependencies = [
  "rmp-serde",
  "serde",
  "serde_json",
- "wit-bindgen 0.42.1",
+ "wit-bindgen",
 ]
 
 [[package]]
@@ -21,7 +21,7 @@ dependencies = [
  "rmp-serde",
  "serde",
  "serde_json",
- "wit-bindgen 0.42.1",
+ "wit-bindgen",
 ]
 
 [[package]]
@@ -104,7 +104,7 @@ dependencies = [
  "hyperware_process_lib 2.1.0",
  "serde",
  "serde_json",
- "wit-bindgen 0.42.1",
+ "wit-bindgen",
 ]
 
 [[package]]
@@ -839,7 +839,7 @@ dependencies = [
  "sha3",
  "url",
  "urlencoding 2.1.3",
- "wit-bindgen 0.42.1",
+ "wit-bindgen",
  "zip 1.1.4",
 ]
 
@@ -1057,18 +1057,6 @@ name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
-
-[[package]]
-name = "auditable-serde"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c7bf8143dfc3c0258df908843e169b5cc5fcf76c7718bd66135ef4a9cd558c5"
-dependencies = [
- "semver 1.0.26",
- "serde",
- "serde_json",
- "topological-sort",
-]
 
 [[package]]
 name = "auto_impl"
@@ -1464,7 +1452,7 @@ dependencies = [
  "hyperware_process_lib 2.1.0",
  "serde",
  "serde_json",
- "wit-bindgen 0.42.1",
+ "wit-bindgen",
 ]
 
 [[package]]
@@ -1534,7 +1522,7 @@ dependencies = [
  "sha3",
  "url",
  "urlencoding 2.1.3",
- "wit-bindgen 0.42.1",
+ "wit-bindgen",
  "zip 1.1.4",
 ]
 
@@ -1623,7 +1611,7 @@ dependencies = [
  "hyperware_process_lib 2.1.0",
  "serde",
  "serde_json",
- "wit-bindgen 0.42.1",
+ "wit-bindgen",
 ]
 
 [[package]]
@@ -1782,7 +1770,7 @@ dependencies = [
  "process_macros",
  "serde",
  "serde_json",
- "wit-bindgen 0.42.1",
+ "wit-bindgen",
 ]
 
 [[package]]
@@ -2460,7 +2448,7 @@ dependencies = [
  "process_macros",
  "serde",
  "serde_json",
- "wit-bindgen 0.42.1",
+ "wit-bindgen",
 ]
 
 [[package]]
@@ -2477,7 +2465,7 @@ dependencies = [
  "sha3",
  "url",
  "urlencoding 2.1.3",
- "wit-bindgen 0.42.1",
+ "wit-bindgen",
  "zip 1.1.4",
 ]
 
@@ -2524,7 +2512,7 @@ name = "echo"
 version = "0.1.0"
 dependencies = [
  "hyperware_process_lib 2.1.0",
- "wit-bindgen 0.42.1",
+ "wit-bindgen",
 ]
 
 [[package]]
@@ -2652,7 +2640,6 @@ name = "explorer"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "file_explorer_caller_utils",
  "hyperprocess_macro 0.1.0 (git+https://github.com/hyperware-ai/hyperprocess-macro?rev=66884c0)",
  "hyperware_process_lib 2.2.0 (git+https://github.com/hyperware-ai/process_lib?rev=4beff93)",
  "md5",
@@ -2661,7 +2648,7 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "tracing",
- "wit-bindgen 0.42.1",
+ "wit-bindgen",
 ]
 
 [[package]]
@@ -2749,22 +2736,6 @@ name = "fiat-crypto"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
-
-[[package]]
-name = "file_explorer_caller_utils"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "futures",
- "futures-util",
- "hyperware_process_lib 2.2.0 (git+https://github.com/hyperware-ai/process_lib?rev=4beff93)",
- "once_cell",
- "process_macros",
- "serde",
- "serde_json",
- "uuid 1.17.0",
- "wit-bindgen 0.41.0",
-]
 
 [[package]]
 name = "fixed-hash"
@@ -2857,7 +2828,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
- "wit-bindgen 0.42.1",
+ "wit-bindgen",
  "zip 1.1.4",
 ]
 
@@ -3030,7 +3001,7 @@ dependencies = [
  "hyperware_process_lib 2.1.0",
  "serde",
  "serde_json",
- "wit-bindgen 0.42.1",
+ "wit-bindgen",
 ]
 
 [[package]]
@@ -3041,7 +3012,7 @@ dependencies = [
  "rmp-serde",
  "serde",
  "serde_json",
- "wit-bindgen 0.42.1",
+ "wit-bindgen",
 ]
 
 [[package]]
@@ -3237,7 +3208,7 @@ name = "help"
 version = "0.1.0"
 dependencies = [
  "hyperware_process_lib 2.1.0",
- "wit-bindgen 0.42.1",
+ "wit-bindgen",
 ]
 
 [[package]]
@@ -3264,7 +3235,7 @@ dependencies = [
  "rmp-serde",
  "serde",
  "serde_json",
- "wit-bindgen 0.42.1",
+ "wit-bindgen",
 ]
 
 [[package]]
@@ -3274,7 +3245,7 @@ dependencies = [
  "hyperware_process_lib 2.1.0",
  "serde",
  "serde_json",
- "wit-bindgen 0.42.1",
+ "wit-bindgen",
 ]
 
 [[package]]
@@ -3345,7 +3316,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 1.0.69",
- "wit-bindgen 0.42.1",
+ "wit-bindgen",
 ]
 
 [[package]]
@@ -3357,7 +3328,7 @@ dependencies = [
  "hyperware_process_lib 2.1.0",
  "serde",
  "serde_json",
- "wit-bindgen 0.42.1",
+ "wit-bindgen",
 ]
 
 [[package]]
@@ -3627,7 +3598,7 @@ dependencies = [
  "rmp-serde",
  "serde",
  "serde_json",
- "wit-bindgen 0.42.1",
+ "wit-bindgen",
 ]
 
 [[package]]
@@ -3703,7 +3674,7 @@ dependencies = [
  "tracing-error",
  "tracing-subscriber",
  "url",
- "wit-bindgen 0.42.1",
+ "wit-bindgen",
 ]
 
 [[package]]
@@ -3733,7 +3704,7 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "uuid 1.17.0",
- "wit-bindgen 0.42.1",
+ "wit-bindgen",
 ]
 
 [[package]]
@@ -3763,7 +3734,7 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "uuid 1.17.0",
- "wit-bindgen 0.42.1",
+ "wit-bindgen",
 ]
 
 [[package]]
@@ -3793,7 +3764,7 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "uuid 1.17.0",
- "wit-bindgen 0.42.1",
+ "wit-bindgen",
 ]
 
 [[package]]
@@ -4028,7 +3999,7 @@ dependencies = [
  "process_macros",
  "serde",
  "serde_json",
- "wit-bindgen 0.42.1",
+ "wit-bindgen",
 ]
 
 [[package]]
@@ -4288,7 +4259,7 @@ dependencies = [
  "hyperware_process_lib 2.1.0",
  "serde",
  "serde_json",
- "wit-bindgen 0.42.1",
+ "wit-bindgen",
 ]
 
 [[package]]
@@ -4330,7 +4301,7 @@ dependencies = [
  "tracing-error",
  "tracing-subscriber",
  "walkdir",
- "wit-bindgen 0.42.1",
+ "wit-bindgen",
  "zip 0.6.6",
 ]
 
@@ -4587,7 +4558,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "wit-bindgen 0.42.1",
+ "wit-bindgen",
 ]
 
 [[package]]
@@ -4757,7 +4728,7 @@ dependencies = [
  "hyperware_process_lib 2.1.0",
  "rmp-serde",
  "serde",
- "wit-bindgen 0.42.1",
+ "wit-bindgen",
 ]
 
 [[package]]
@@ -4801,7 +4772,7 @@ dependencies = [
  "process_macros",
  "serde",
  "serde_json",
- "wit-bindgen 0.42.1",
+ "wit-bindgen",
 ]
 
 [[package]]
@@ -5185,7 +5156,7 @@ dependencies = [
  "hyperware_process_lib 2.1.0",
  "rmp-serde",
  "serde",
- "wit-bindgen 0.42.1",
+ "wit-bindgen",
 ]
 
 [[package]]
@@ -5195,7 +5166,7 @@ dependencies = [
  "hyperware_process_lib 2.1.0",
  "rmp-serde",
  "serde",
- "wit-bindgen 0.42.1",
+ "wit-bindgen",
 ]
 
 [[package]]
@@ -5788,7 +5759,7 @@ dependencies = [
  "rmp-serde",
  "serde",
  "serde_json",
- "wit-bindgen 0.42.1",
+ "wit-bindgen",
 ]
 
 [[package]]
@@ -5839,7 +5810,7 @@ dependencies = [
  "process_macros",
  "serde",
  "serde_json",
- "wit-bindgen 0.42.1",
+ "wit-bindgen",
 ]
 
 [[package]]
@@ -5850,7 +5821,7 @@ dependencies = [
  "process_macros",
  "serde",
  "serde_json",
- "wit-bindgen 0.42.1",
+ "wit-bindgen",
 ]
 
 [[package]]
@@ -5862,7 +5833,7 @@ dependencies = [
  "process_macros",
  "serde",
  "serde_json",
- "wit-bindgen 0.42.1",
+ "wit-bindgen",
 ]
 
 [[package]]
@@ -6376,7 +6347,7 @@ dependencies = [
  "process_macros",
  "serde",
  "serde_json",
- "wit-bindgen 0.42.1",
+ "wit-bindgen",
 ]
 
 [[package]]
@@ -6390,7 +6361,7 @@ dependencies = [
  "serde",
  "serde_json",
  "url",
- "wit-bindgen 0.42.1",
+ "wit-bindgen",
 ]
 
 [[package]]
@@ -6460,7 +6431,7 @@ dependencies = [
  "rmp-serde",
  "serde",
  "serde_json",
- "wit-bindgen 0.42.1",
+ "wit-bindgen",
 ]
 
 [[package]]
@@ -6592,15 +6563,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "spdx"
-version = "0.10.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3e17e880bafaeb362a7b751ec46bdc5b61445a188f80e0606e68167cd540fa3"
-dependencies = [
- "smallvec",
-]
-
-[[package]]
 name = "spider"
 version = "0.1.0"
 dependencies = [
@@ -6617,27 +6579,10 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
- "spider_caller_utils",
  "url",
  "uuid 1.17.0",
- "wit-bindgen 0.42.1",
+ "wit-bindgen",
  "wit-parser 0.220.1",
-]
-
-[[package]]
-name = "spider_caller_utils"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "futures",
- "futures-util",
- "hyperware_process_lib 2.2.0 (git+https://github.com/hyperware-ai/process_lib?rev=232fe25)",
- "once_cell",
- "process_macros",
- "serde",
- "serde_json",
- "uuid 1.17.0",
- "wit-bindgen 0.41.0",
 ]
 
 [[package]]
@@ -6686,7 +6631,7 @@ dependencies = [
  "process_macros",
  "serde",
  "serde_json",
- "wit-bindgen 0.42.1",
+ "wit-bindgen",
 ]
 
 [[package]]
@@ -6697,7 +6642,7 @@ dependencies = [
  "process_macros",
  "serde",
  "serde_json",
- "wit-bindgen 0.42.1",
+ "wit-bindgen",
 ]
 
 [[package]]
@@ -6731,7 +6676,7 @@ dependencies = [
  "process_macros",
  "serde",
  "serde_json",
- "wit-bindgen 0.42.1",
+ "wit-bindgen",
 ]
 
 [[package]]
@@ -6922,7 +6867,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "wit-bindgen 0.42.1",
+ "wit-bindgen",
 ]
 
 [[package]]
@@ -6936,7 +6881,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 1.0.69",
- "wit-bindgen 0.42.1",
+ "wit-bindgen",
 ]
 
 [[package]]
@@ -7215,14 +7160,8 @@ dependencies = [
  "hyperware_process_lib 2.1.0",
  "serde",
  "serde_json",
- "wit-bindgen 0.42.1",
+ "wit-bindgen",
 ]
-
-[[package]]
-name = "topological-sort"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea68304e134ecd095ac6c3574494fc62b909f416c4fca77e440530221e549d3d"
 
 [[package]]
 name = "tower"
@@ -7584,7 +7523,7 @@ dependencies = [
  "process_macros",
  "serde",
  "serde_json",
- "wit-bindgen 0.42.1",
+ "wit-bindgen",
 ]
 
 [[package]]
@@ -7844,16 +7783,6 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
-version = "0.227.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80bb72f02e7fbf07183443b27b0f3d4144abf8c114189f2e088ed95b696a7822"
-dependencies = [
- "leb128fmt",
- "wasmparser 0.227.1",
-]
-
-[[package]]
-name = "wasm-encoder"
 version = "0.229.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38ba1d491ecacb085a2552025c10a675a6fddcbd03b1fc9b36c536010ce265d2"
@@ -7884,25 +7813,6 @@ dependencies = [
 
 [[package]]
 name = "wasm-metadata"
-version = "0.227.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce1ef0faabbbba6674e97a56bee857ccddf942785a336c8b47b42373c922a91d"
-dependencies = [
- "anyhow",
- "auditable-serde",
- "flate2",
- "indexmap",
- "serde",
- "serde_derive",
- "serde_json",
- "spdx",
- "url",
- "wasm-encoder 0.227.1",
- "wasmparser 0.227.1",
-]
-
-[[package]]
-name = "wasm-metadata"
 version = "0.230.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a52e010df5494f4289ccc68ce0c2a8c17555225a5e55cc41b98f5ea28d0844b"
@@ -7920,18 +7830,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d07b6a3b550fefa1a914b6d54fc175dd11c3392da11eee604e6ffc759805d25"
 dependencies = [
  "bitflags 2.9.1",
- "indexmap",
- "semver 1.0.26",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.227.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f51cad774fb3c9461ab9bccc9c62dfb7388397b5deda31bf40e8108ccd678b2"
-dependencies = [
- "bitflags 2.9.1",
- "hashbrown 0.15.4",
  "indexmap",
  "semver 1.0.26",
 ]
@@ -8779,33 +8677,12 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen"
-version = "0.41.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10fb6648689b3929d56bbc7eb1acf70c9a42a29eb5358c67c10f54dbd5d695de"
-dependencies = [
- "wit-bindgen-rt 0.41.0",
- "wit-bindgen-rust-macro 0.41.0",
-]
-
-[[package]]
-name = "wit-bindgen"
 version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa5b79cd8cb4b27a9be3619090c03cbb87fe7b1c6de254b4c9b4477188828af8"
 dependencies = [
  "wit-bindgen-rt 0.42.1",
- "wit-bindgen-rust-macro 0.42.1",
-]
-
-[[package]]
-name = "wit-bindgen-core"
-version = "0.41.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92fa781d4f2ff6d3f27f3cc9b74a73327b31ca0dc4a3ef25a0ce2983e0e5af9b"
-dependencies = [
- "anyhow",
- "heck 0.5.0",
- "wit-parser 0.227.1",
+ "wit-bindgen-rust-macro",
 ]
 
 [[package]]
@@ -8830,17 +8707,6 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen-rt"
-version = "0.41.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4db52a11d4dfb0a59f194c064055794ee6564eb1ced88c25da2cf76e50c5621"
-dependencies = [
- "bitflags 2.9.1",
- "futures",
- "once_cell",
-]
-
-[[package]]
-name = "wit-bindgen-rt"
 version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "051105bab12bc78e161f8dfb3596e772dd6a01ebf9c4840988e00347e744966a"
@@ -8848,22 +8714,6 @@ dependencies = [
  "bitflags 2.9.1",
  "futures",
  "once_cell",
-]
-
-[[package]]
-name = "wit-bindgen-rust"
-version = "0.41.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d0809dc5ba19e2e98661bf32fc0addc5a3ca5bf3a6a7083aa6ba484085ff3ce"
-dependencies = [
- "anyhow",
- "heck 0.5.0",
- "indexmap",
- "prettyplease",
- "syn 2.0.104",
- "wasm-metadata 0.227.1",
- "wit-bindgen-core 0.41.0",
- "wit-component 0.227.1",
 ]
 
 [[package]]
@@ -8877,24 +8727,9 @@ dependencies = [
  "indexmap",
  "prettyplease",
  "syn 2.0.104",
- "wasm-metadata 0.230.0",
- "wit-bindgen-core 0.42.1",
- "wit-component 0.230.0",
-]
-
-[[package]]
-name = "wit-bindgen-rust-macro"
-version = "0.41.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad19eec017904e04c60719592a803ee5da76cb51c81e3f6fbf9457f59db49799"
-dependencies = [
- "anyhow",
- "prettyplease",
- "proc-macro2",
- "quote",
- "syn 2.0.104",
- "wit-bindgen-core 0.41.0",
- "wit-bindgen-rust 0.41.0",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
 ]
 
 [[package]]
@@ -8908,27 +8743,8 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.104",
- "wit-bindgen-core 0.42.1",
- "wit-bindgen-rust 0.42.1",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.227.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "635c3adc595422cbf2341a17fb73a319669cc8d33deed3a48368a841df86b676"
-dependencies = [
- "anyhow",
- "bitflags 2.9.1",
- "indexmap",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder 0.227.1",
- "wasm-metadata 0.227.1",
- "wasmparser 0.227.1",
- "wit-parser 0.227.1",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
 ]
 
 [[package]]
@@ -8945,7 +8761,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "wasm-encoder 0.230.0",
- "wasm-metadata 0.230.0",
+ "wasm-metadata",
  "wasmparser 0.230.0",
  "wit-parser 0.230.0",
 ]
@@ -8966,24 +8782,6 @@ dependencies = [
  "serde_json",
  "unicode-xid",
  "wasmparser 0.220.1",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.227.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddf445ed5157046e4baf56f9138c124a0824d4d1657e7204d71886ad8ce2fc11"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap",
- "log",
- "semver 1.0.26",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser 0.227.1",
 ]
 
 [[package]]

--- a/hyperdrive/src/kernel/mod.rs
+++ b/hyperdrive/src/kernel/mod.rs
@@ -95,7 +95,6 @@ async fn handle_kernel_request(
     process_map: &mut t::ProcessMap,
     caps_oracle: &t::CapMessageSender,
     engine: &Engine,
-    home_directory_path: &PathBuf,
     process_restart_backoffs: &mut ProcessRestartBackoffs,
 ) -> Option<()> {
     let t::Message::Request(request) = km.message else {
@@ -290,7 +289,6 @@ async fn handle_kernel_request(
                 engine,
                 caps_oracle,
                 &start_process_metadata,
-                &home_directory_path,
                 process_restart_backoffs,
             )
             .await
@@ -550,7 +548,6 @@ async fn start_process(
     engine: &Engine,
     caps_oracle: &t::CapMessageSender,
     process_metadata: &StartProcessMetadata,
-    home_directory_path: &PathBuf,
     process_restart_backoffs: &mut ProcessRestartBackoffs,
 ) -> anyhow::Result<()> {
     let (send_to_process, recv_in_process) =
@@ -594,7 +591,6 @@ async fn start_process(
             km_blob_bytes,
             caps_oracle.clone(),
             engine.clone(),
-            home_directory_path.clone(),
             maybe_restart_backoff,
         )),
     );
@@ -747,7 +743,6 @@ pub async fn kernel(
             &engine,
             &caps_oracle_sender,
             &start_process_metadata,
-            &home_directory_path,
             &mut process_restart_backoffs,
         )
         .await
@@ -1030,7 +1025,6 @@ pub async fn kernel(
                         &mut process_map,
                         &caps_oracle_sender,
                         &engine,
-                        &home_directory_path,
                         &mut process_restart_backoffs,
                     ).await {
                         // drain process map of processes with OnExit::None

--- a/hyperdrive/src/kernel/process.rs
+++ b/hyperdrive/src/kernel/process.rs
@@ -13,11 +13,8 @@ use wasmtime::{
     component::{Component, Linker, ResourceTable as Table},
     Engine, Store,
 };
-use wasmtime_wasi::{
-    p2::{
-        pipe::MemoryOutputPipe, IoView, StdoutStream, StreamResult, WasiCtx, WasiCtxBuilder,
-        WasiView,
-    },
+use wasmtime_wasi::p2::{
+    pipe::MemoryOutputPipe, IoView, StdoutStream, StreamResult, WasiCtx, WasiCtxBuilder, WasiView,
 };
 use wasmtime_wasi_io::{async_trait, poll::Pollable, streams::OutputStream};
 

--- a/hyperdrive/src/kernel/process.rs
+++ b/hyperdrive/src/kernel/process.rs
@@ -3,13 +3,12 @@ use bytes::{BufMut, Bytes, BytesMut};
 use lib::{types::core as t, v1::ProcessV1};
 use std::{
     collections::{HashMap, VecDeque},
-    path::PathBuf,
     sync::{
         atomic::{AtomicUsize, Ordering},
         Arc, Mutex as StdMutex,
     },
 };
-use tokio::{fs, sync::Mutex, task::JoinHandle};
+use tokio::{sync::Mutex, task::JoinHandle};
 use wasmtime::{
     component::{Component, Linker, ResourceTable as Table},
     Engine, Store,
@@ -19,7 +18,6 @@ use wasmtime_wasi::{
         pipe::MemoryOutputPipe, IoView, StdoutStream, StreamResult, WasiCtx, WasiCtxBuilder,
         WasiView,
     },
-    DirPerms, FilePerms,
 };
 use wasmtime_wasi_io::{async_trait, poll::Pollable, streams::OutputStream};
 
@@ -83,48 +81,11 @@ impl WasiView for ProcessWasiV1 {
     }
 }
 
-async fn make_table_and_wasi(
-    home_directory_path: PathBuf,
-    process_state: &ProcessState,
-) -> (Table, WasiCtx, RotatingOutputPipe) {
+async fn make_table_and_wasi() -> (Table, WasiCtx, RotatingOutputPipe) {
     let table = Table::new();
     let wasi_stderr = RotatingOutputPipe::new(STACK_TRACE_SIZE);
 
-    #[cfg(unix)]
-    let tmp_path = home_directory_path
-        .join("vfs")
-        .join(format!(
-            "{}:{}",
-            process_state.metadata.our.process.package(),
-            process_state.metadata.our.process.publisher()
-        ))
-        .join("tmp");
-    #[cfg(target_os = "windows")]
-    let tmp_path = home_directory_path
-        .join("vfs")
-        .join(format!(
-            "{}_{}",
-            process_state.metadata.our.process.package(),
-            process_state.metadata.our.process.publisher()
-        ))
-        .join("tmp");
-
-    let tmp_path = tmp_path.to_str().unwrap();
-
     let mut wasi = WasiCtxBuilder::new();
-
-    // TODO make guarantees about this
-    if let Ok(Ok(())) = tokio::time::timeout(
-        std::time::Duration::from_secs(5),
-        fs::create_dir_all(&tmp_path),
-    )
-    .await
-    {
-        if let Ok(wasi) = wasi.preopened_dir(tmp_path, tmp_path, DirPerms::all(), FilePerms::all())
-        {
-            wasi.env("TEMP_DIR", tmp_path);
-        }
-    }
 
     (table, wasi.stderr(wasi_stderr.clone()).build(), wasi_stderr)
 }
@@ -132,7 +93,6 @@ async fn make_table_and_wasi(
 async fn make_component_v1(
     engine: Engine,
     wasm_bytes: &[u8],
-    home_directory_path: PathBuf,
     process_state: ProcessState,
 ) -> anyhow::Result<(ProcessV1, Store<ProcessWasiV1>, RotatingOutputPipe)> {
     let our_process_id = process_state.metadata.our.process.clone();
@@ -154,7 +114,7 @@ async fn make_component_v1(
 
     let mut linker = Linker::new(&engine);
     ProcessV1::add_to_linker(&mut linker, |state: &mut ProcessWasiV1| state).unwrap();
-    let (table, wasi, wasi_stderr) = make_table_and_wasi(home_directory_path, &process_state).await;
+    let (table, wasi, wasi_stderr) = make_table_and_wasi().await;
     wasmtime_wasi::p2::add_to_linker_async(&mut linker).unwrap();
     let mut store = Store::new(
         &engine,
@@ -193,7 +153,6 @@ pub async fn make_process_loop(
     wasm_bytes: Vec<u8>,
     caps_oracle: t::CapMessageSender,
     engine: Engine,
-    home_directory_path: PathBuf,
     maybe_restart_backoff: Option<Arc<Mutex<Option<RestartBackoff>>>>,
 ) -> anyhow::Result<()> {
     // before process can be instantiated, need to await 'run' message from kernel
@@ -252,7 +211,7 @@ pub async fn make_process_loop(
         // assume missing version is oldest wit version
         None | Some(1) | _ => {
             let (bindings, mut store, wasi_stderr) =
-                make_component_v1(engine, &wasm_bytes, home_directory_path, process_state).await?;
+                make_component_v1(engine, &wasm_bytes, process_state).await?;
 
             // the process will run until it returns from init() or crashes
             match bindings.call_init(&mut store, &our.to_string()).await {


### PR DESCRIPTION
## Problem

We can't control temp dir writes, meaning a rogue process can write until disk is full

## Solution

Remove temp dir

## Testing

None

## Docs Update

None

## Notes

This is technically a breaking change, but no one uses this feature, so we'll pretend it isn't :sweat_smile: 