### PR TITLE
app-store: fix public refresh and links

### DIFF
--- a/hyperdrive/packages/app-store/app-store/src/http_api.rs
+++ b/hyperdrive/packages/app-store/app-store/src/http_api.rs
@@ -174,7 +174,7 @@ fn make_widget() -> String {
     <h3>Top Apps</h3>
     <div id="latest-apps"></div>
     <script>
-    
+
 class HWProtocolWatcher {
     constructor() {
         this.isListening = false;
@@ -245,7 +245,7 @@ if (typeof document !== 'undefined') {
     }
 }
 
-    
+
 
 
     </script>
@@ -394,7 +394,7 @@ fn serve_public_ui(http_server: &mut server::HttpServer) {
     http_server
         .serve_ui(
             "public-ui",
-            vec!["/public"],
+            vec!["/public", "/public/app", "/public/app/:id"],
             server::HttpBindingConfig::default().authenticated(false),
         )
         .expect("failed to serve static public UI");

--- a/hyperdrive/packages/app-store/public-ui/src/App.tsx
+++ b/hyperdrive/packages/app-store/public-ui/src/App.tsx
@@ -10,12 +10,28 @@ const BASE_URL = import.meta.env.BASE_URL;
 if (window.our) window.our.process = BASE_URL?.replace("/", "");
 
 function App() {
+  const trimmedBase =
+    !BASE_URL || BASE_URL === "/"
+      ? ""
+      : BASE_URL.endsWith("/")
+        ? BASE_URL.slice(0, -1)
+        : BASE_URL;
+  const normalizedBase =
+    trimmedBase.length === 0
+      ? "/"
+      : trimmedBase.startsWith("/")
+        ? trimmedBase
+        : `/${trimmedBase}`;
+
   const getBasename = () => {
     const path = window.location.pathname;
-    if (path.startsWith('/main:app-store:sys/public')) {
-      return '/main:app-store:sys/public';
+    if (
+      normalizedBase !== "/" &&
+      path.startsWith(normalizedBase)
+    ) {
+      return normalizedBase;
     }
-    return '/';
+    return "/";
   };
 
   return (

--- a/hyperdrive/packages/app-store/public-ui/src/components/AppDetail.tsx
+++ b/hyperdrive/packages/app-store/public-ui/src/components/AppDetail.tsx
@@ -54,9 +54,21 @@ export default function AppDetail() {
         }
     }, [backtickPressCount]);
 
+    const derivedId = React.useMemo(() => {
+        if (id) return id;
+        const match = window.location.pathname.match(/\/app\/([^/?#]+)/);
+        if (match && match[1]) {
+            return decodeURIComponent(match[1]);
+        }
+        return undefined;
+    }, [id]);
+
     useEffect(() => {
         const loadApp = async () => {
-            if (!id) return;
+            if (!derivedId) {
+                setIsLoading(false);
+                return;
+            }
             setIsLoading(true);
             setError(null);
 
@@ -64,7 +76,8 @@ export default function AppDetail() {
                 if (isDevMode) {
                     setApp(mockApp);
                 } else {
-                    const response = await fetch(`/main:app-store:sys/apps-public/${id}`);
+                    const encodedId = encodeURIComponent(derivedId).replace(/%3A/g, ":");
+                    const response = await fetch(`/main:app-store:sys/apps-public/${encodedId}`);
                     if (!response.ok) {
                         throw new Error('Failed to fetch app details');
                     }
@@ -81,7 +94,7 @@ export default function AppDetail() {
 
         loadApp();
         window.scrollTo(0, 0);
-    }, [id, isDevMode]);
+    }, [derivedId, isDevMode]);
 
     if (isLoading) {
         return (
@@ -102,7 +115,7 @@ export default function AppDetail() {
     if (!app) {
         return (
             <div className="max-w-screen md:max-w-screen-md mx-auto flex flex-col items-center justify-center min-h-96">
-                <div>App details not found for {id}</div>
+                <div>App details not found for {derivedId ?? "unknown app"}</div>
             </div>
         );
     }

--- a/scripts/build-packages/Cargo.toml
+++ b/scripts/build-packages/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 anyhow = "1.0.71"
 clap = "4"
 fs-err = "2.11"
-kit = { git = "https://github.com/hyperware-ai/kit", rev = "275f02c" }
+kit = { git = "https://github.com/hyperware-ai/kit", rev = "0d0469e" }
 rayon = "1.8"
 serde = "1"
 serde_json = "1"


### PR DESCRIPTION
## Problem

resolves #818

## Solution

Update Caddyfile & App Store to avoid redirecting to secure subdomain (which is intrinsically non-public!)

## Testing

Click around on https://apps.hyperware.ai

Does refreshing work?

Do links to apps work?

## Docs Update

None

## Notes

The relevant part of the Caddyfile:

```
apps.hyperware.ai {
    # Only rewrite paths that are NOT ACME challenges or assets
    @notacme_notassets {
        not path /.well-known/acme-challenge/*
        not path /assets/*
        not path /app/assets/*
        not path /*.woff
        not path /our.js
        not path /main:app-store:sys/apps-public
        not path /main:app-store:sys/apps-public/*
    }
    
    # Rewrite assets to the correct path
    @assets {
        path /assets/*
    }
    @appassets path_regexp appassets ^/app/assets/(.*)
    @our {
        path /our.js
        path /*.woff
        path /main:app-store:sys/apps-public
        path /main:app-store:sys/apps-public/*
    }
    
    rewrite @our {uri}
    rewrite @assets /main:app-store:sys{uri}
    rewrite @appassets /main:app-store:sys/assets/{re.appassets.1}
    rewrite @notacme_notassets /main:app-store:sys/public{uri}
    reverse_proxy localhost:8080
}
```